### PR TITLE
testbench: add tests for imuxsock system log socket

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -100,6 +100,9 @@ TESTS +=  \
 	imuxsock_logger_parserchain.sh \
 	imuxsock_traillf.sh \
 	imuxsock_ccmiddle.sh \
+	imuxsock_logger_syssock.sh \
+	imuxsock_traillf_syssock.sh \
+	imuxsock_ccmiddle_syssock.sh \
 	imuxsock_logger_root.sh \
 	imuxsock_traillf_root.sh \
 	imuxsock_ccmiddle_root.sh \
@@ -876,16 +879,19 @@ EXTRA_DIST= \
 	imuxsock_logger_err.sh \
 	imuxsock_logger_root.sh \
 	testsuites/imuxsock_logger_root.conf \
+	testsuites/imuxsock_logger_syssock.conf \
 	resultdata/imuxsock_logger.log \
 	imuxsock_traillf.sh \
 	testsuites/imuxsock_traillf.conf \
 	imuxsock_traillf_root.sh \
 	testsuites/imuxsock_traillf_root.conf \
+	testsuites/imuxsock_traillf_syssock.conf \
 	resultdata/imuxsock_traillf.log \
 	imuxsock_ccmiddle.sh \
 	testsuites/imuxsock_ccmiddle.conf \
 	imuxsock_ccmiddle_root.sh \
 	testsuites/imuxsock_ccmiddle_root.conf \
+	testsuites/imuxsock_ccmiddle_syssock.conf \
 	resultdata/imuxsock_ccmiddle.log \
 	imuxsock_hostname.sh \
 	testsuites/imuxsock_hostname.conf \

--- a/tests/imuxsock_ccmiddle_syssock.sh
+++ b/tests/imuxsock_ccmiddle_syssock.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+echo \[imuxsock_ccmiddle_syssock.sh\]: test trailing LF handling in imuxsock
+./syslog_caller -fsyslog_inject-l -m0 > /dev/null 2>&1
+no_liblogging_stdlog=$?
+if [ $no_liblogging_stdlog -ne 0 ];then
+  echo "liblogging-stdlog not available - skipping test"
+  exit 77
+fi
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup imuxsock_ccmiddle_syssock.conf
+# send a message with trailing LF
+./syslog_caller -fsyslog_inject-c -m1 -C "uxsock:testbench_socket"
+# the sleep below is needed to prevent too-early termination of rsyslogd
+./msleep 100
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown	# we need to wait until rsyslogd is finished!
+cmp rsyslog.out.log $srcdir/resultdata/imuxsock_ccmiddle_syssock.log
+if [ ! $? -eq 0 ]; then
+  echo "imuxsock_ccmiddle_syssock.sh failed"
+  echo contents of rsyslog.out.log:
+  echo \"`cat rsyslog.out.log`\"
+  exit 1
+fi;
+. $srcdir/diag.sh exit

--- a/tests/imuxsock_logger_syssock.sh
+++ b/tests/imuxsock_logger_syssock.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# note: we use the system socket, but assign a different name to
+# it. This is not 100% the same thing as running as root, but it
+# is pretty close to it. -- rgerhards, 201602-19
+echo \[imuxsock_logger_syssock.sh\]: test trailing LF handling in imuxsock
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup imuxsock_logger_syssock.conf
+# send a message with trailing LF
+logger -d -u testbench_socket test
+# the sleep below is needed to prevent too-early termination of rsyslogd
+./msleep 100
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown	# we need to wait until rsyslogd is finished!
+cmp rsyslog.out.log $srcdir/resultdata/imuxsock_logger.log
+if [ ! $? -eq 0 ]; then
+  echo "imuxsock_logger_syssock.sh failed"
+  echo contents of rsyslog.out.log:
+  echo \"`cat rsyslog.out.log`\"
+  exit 1
+fi;
+. $srcdir/diag.sh exit

--- a/tests/imuxsock_traillf_syssock.sh
+++ b/tests/imuxsock_traillf_syssock.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+./syslog_caller -fsyslog_inject-l -m0 > /dev/null 2>&1
+no_liblogging_stdlog=$?
+if [ $no_liblogging_stdlog -ne 0 ];then
+  echo "liblogging-stdlog not available - skipping test"
+  exit 77
+fi
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup imuxsock_traillf_syssock.conf
+# send a message with trailing LF
+./syslog_caller -fsyslog_inject-l -m1 -C "uxsock:testbench_socket"
+# the sleep below is needed to prevent too-early termination of rsyslogd
+./msleep 100
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown	# we need to wait until rsyslogd is finished!
+cmp rsyslog.out.log $srcdir/resultdata/imuxsock_traillf.log
+if [ ! $? -eq 0 ]; then
+  echo "imuxsock_traillf_syssock failed"
+  echo contents of rsyslog.out.log:
+  echo \"`cat rsyslog.out.log`\"
+  exit 1
+fi;
+. $srcdir/diag.sh exit

--- a/tests/testsuites/imuxsock_ccmiddle_syssock.conf
+++ b/tests/testsuites/imuxsock_ccmiddle_syssock.conf
@@ -1,0 +1,7 @@
+$IncludeConfig diag-common.conf
+
+module(load="../plugins/imuxsock/.libs/imuxsock"
+       SysSock.name="testbench_socket")
+
+template(name="outfmt" type="string" string="%msg:%\n")
+local1.*	./rsyslog.out.log;outfmt

--- a/tests/testsuites/imuxsock_logger_syssock.conf
+++ b/tests/testsuites/imuxsock_logger_syssock.conf
@@ -1,0 +1,8 @@
+# rgerhards, 2011-02-21
+$IncludeConfig diag-common.conf
+
+module(load="../plugins/imuxsock/.libs/imuxsock"
+       SysSock.name="testbench_socket")
+
+$template outfmt,"%msg:%\n"
+*.notice	./rsyslog.out.log;outfmt

--- a/tests/testsuites/imuxsock_traillf_syssock.conf
+++ b/tests/testsuites/imuxsock_traillf_syssock.conf
@@ -1,0 +1,7 @@
+$IncludeConfig diag-common.conf
+
+module(load="../plugins/imuxsock/.libs/imuxsock"
+       SysSock.name="testbench_socket")
+
+template(name="outfmt" type="string" string="%msg:%\n")
+local1.*	action(type="omfile" file="rsyslog.out.log" template="outfmt")


### PR DESCRIPTION
We do not exectute them as root, but we assign a special name. This
is very close to the "real thing" but permits us to execute the
tests as part of CI platforms.