### PR TITLE
This is what I mean

### DIFF
--- a/action.c
+++ b/action.c
@@ -1288,9 +1288,6 @@ actionCommit(action_t *__restrict__ const pThis, wti_t *__restrict__ const pWti)
 				bDone = 1;
 			}
 			continue;
-		}
-		if(iRet == RS_RET_FORCE_TERM) {
-			ABORT_FINALIZE(RS_RET_FORCE_TERM);
 		} else if(iRet == RS_RET_OK ||
 		          iRet == RS_RET_SUSPENDED ||
 			  iRet == RS_RET_ACTION_FAILED) {


### PR DESCRIPTION
@rgerhards, it seems this logic is redundant.  If `actionTryCommit()` called on line 1279 returns a value in `iRet`, then that value cannot be `RS_RET_FORCE_TERM` on line 1292 because we would have `ABORT_FINALIZE()`'d on line 1283.  If however, `actionTryCommit()` returns `RS_RET_SUSPENDED`, then `iRet` is set to the value returned by `actionDoRetry()` on line 1285, but the `continue` statement on line 1290 prevents us from dropping through to line 1292.

So line 1292 appears to be redundant and can removed.
