### PR TITLE
add global parameter oversizemsg.input.mode

### DIFF
--- a/runtime/glbl.h
+++ b/runtime/glbl.h
@@ -38,6 +38,9 @@
 #include "prop.h"
 
 #define glblGetIOBufSize() 4096 /* size of the IO buffer, e.g. for strm class */
+#define glblOversizeMsgInputMode_Truncate 0
+#define glblOversizeMsgInputMode_Split 1
+
 
 extern pid_t glbl_ourpid;
 extern int bProcessInternalMessages;
@@ -148,5 +151,6 @@ int GetGnuTLSLoglevel(void);
 int glblGetMaxLine(void);
 int bs_arrcmp_glblDbgFiles(const void *s1, const void *s2);
 uchar* glblGetOversizeMsgErrorFile(void);
+int glblGetOversizeMsgInputMode(void);
 
 #endif /* #ifndef GLBL_H_INCLUDED */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -384,6 +384,7 @@ TESTS +=  \
 	mmexternal-SegFault-vg.sh \
 	mmexternal-InvldProg-vg.sh \
 	internal-errmsg-memleak-vg.sh \
+	glbl-oversizeMsg-log-vg.sh \
 	rscript_set_memleak-vg.sh \
 	no-parser-vg.sh \
 	discard-rptdmsg-vg.sh \
@@ -725,7 +726,9 @@ TESTS += sndrcv_relp.sh \
 	 imrelp-long-msg.sh \
 	 imrelp-oversizeMode-truncate.sh \
 	 imrelp-oversizeMode-accept.sh \
-	 general-oversize-msg.sh
+	 glbl-oversizeMsg-log.sh \
+	 glbl-oversizeMsg-truncate.sh \
+	 glbl-oversizeMsg-split.sh
 if ENABLE_GNUTLS
 TESTS += \
          sndrcv_relp_tls.sh \
@@ -808,7 +811,8 @@ TESTS += \
 	imfile-wildcards-dirs-multi5-polling.sh \
 	imfile-old-state-file.sh \
 	imfile-rename-while-stopped.sh \
-	imfile-rename.sh
+	imfile-rename.sh \
+	glbl-oversizeMsg-truncate-imfile.sh
 
 if HAVE_VALGRIND
 TESTS += \
@@ -842,6 +846,7 @@ test_files = testbench.h runtime-dummy.c
 
 EXTRA_DIST= \
 	internal-errmsg-memleak-vg.sh \
+	glbl-oversizeMsg-log-vg.sh \
 	empty-hostname.sh \
 	hostname-getaddrinfo-fail.sh \
 	hostname-with-slash-pmrfc5424.sh \
@@ -1376,6 +1381,9 @@ EXTRA_DIST= \
 	imrelp-long-msg.sh \
 	imrelp-oversizeMode-truncate.sh \
 	imrelp-oversizeMode-accept.sh \
+	glbl-oversizeMsg-log.sh \
+	glbl-oversizeMsg-truncate.sh \
+	glbl-oversizeMsg-split.sh \
 	general-oversize-msg.sh \
 	sndrcv_relp.sh \
 	testsuites/sndrcv_relp_sender.conf \
@@ -1536,6 +1544,7 @@ EXTRA_DIST= \
 	imfile-old-state-file.sh \
 	imfile-rename-while-stopped.sh \
 	imfile-rename.sh \
+	glbl-oversizeMsg-truncate-imfile.sh \
 	testsuites/imfile-wildcards-simple.conf \
 	testsuites/imfile-wildcards-dirs.conf \
 	testsuites/imfile-wildcards-dirs-multi.conf \

--- a/tests/glbl-oversizeMsg-log-vg.sh
+++ b/tests/glbl-oversizeMsg-log-vg.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# add 2018-05-03 by PascalWithopf, released under ASL 2.0
+. $srcdir/diag.sh init
+./have_relpSrvSetOversizeMode
+if [ $? -eq 1 ]; then
+  echo "imrelp parameter oversizeMode not available. Test stopped"
+  exit 77
+fi;
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imrelp/.libs/imrelp")
+global(maxMessageSize="230"
+	oversizemsg.errorfile="rsyslog2.out.log")
+
+
+input(type="imrelp" port="13514" maxdatasize="300")
+
+template(name="outfmt" type="string" string="%rawmsg%\n")
+action(type="omfile" template="outfmt"
+				 file="rsyslog.out.log")
+'
+# TODO: add tcpflood option to specific EXACT test message size!
+. $srcdir/diag.sh startup-vg
+. $srcdir/diag.sh tcpflood -Trelp-plain -p13514 -m1 -d 240
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown-vg
+. $srcdir/diag.sh check-exit-vg
+grep "rawmsg.*<167>Mar  1 01:00:00 172.20.245.8 tag msgnum:00000000:240:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.*input.*imrelp" rsyslog2.out.log > /dev/null
+if [ $? -ne 0 ]; then
+        echo
+        echo "FAIL: expected message not found. rsyslog2.out.log is:"
+        cat rsyslog2.out.log
+        . $srcdir/diag.sh error-exit 1
+fi
+
+
+. $srcdir/diag.sh exit

--- a/tests/glbl-oversizeMsg-log.sh
+++ b/tests/glbl-oversizeMsg-log.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# add 2018-05-03 by PascalWithopf, released under ASL 2.0
+. $srcdir/diag.sh init
+./have_relpSrvSetOversizeMode
+if [ $? -eq 1 ]; then
+  echo "imrelp parameter oversizeMode not available. Test stopped"
+  exit 77
+fi;
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imrelp/.libs/imrelp")
+global(maxMessageSize="230"
+	oversizemsg.errorfile="rsyslog2.out.log")
+
+
+input(type="imrelp" port="13514" maxdatasize="300")
+
+template(name="outfmt" type="string" string="%rawmsg%\n")
+action(type="omfile" template="outfmt"
+				 file="rsyslog.out.log")
+'
+# TODO: add tcpflood option to specific EXACT test message size!
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh tcpflood -Trelp-plain -p13514 -m1 -d 240
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown
+
+grep "rawmsg.*<167>Mar  1 01:00:00 172.20.245.8 tag msgnum:00000000:240:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.*input.*imrelp" rsyslog2.out.log > /dev/null
+if [ $? -ne 0 ]; then
+        echo
+        echo "FAIL: expected message not found. rsyslog2.out.log is:"
+        cat rsyslog2.out.log
+        . $srcdir/diag.sh error-exit 1
+fi
+
+
+. $srcdir/diag.sh exit

--- a/tests/glbl-oversizeMsg-truncate-imfile.sh
+++ b/tests/glbl-oversizeMsg-truncate-imfile.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# add 2018-05-02 by PascalWithopf, released under ASL 2.0
+. $srcdir/diag.sh init
+./have_relpSrvSetOversizeMode
+if [ $? -eq 1 ]; then
+  echo "imrelp parameter oversizeMode not available. Test stopped"
+  exit 77
+fi;
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imfile/.libs/imfile")
+global(maxMessageSize="230"
+	oversizemsg.input.mode="truncate")
+
+
+input(type="imfile" File="./rsyslog.input" tag="tag:")
+
+template(name="outfmt" type="string" string="%rawmsg%\n")
+action(type="omfile" template="outfmt"
+				 file="rsyslog.out.log")
+'
+# TODO: add tcpflood option to specific EXACT test message size!
+. $srcdir/diag.sh startup
+echo '<167>Mar  1 01:00:00 172.20.245.8 tag msgnum:00000000:240:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX' > rsyslog.input
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown
+
+# We need the ^-sign to symbolize the beginning and the $-sign to symbolize the end
+# because otherwise we won't know if it was truncated at the right length.
+grep "^<167>Mar  1 01:00:00 172.20.245.8 tag msgnum:00000000:240:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX$" rsyslog.out.log > /dev/null
+if [ $? -ne 0 ]; then
+        echo
+        echo "FAIL: expected message not found. rsyslog.out.log is:"
+        cat rsyslog.out.log
+        . $srcdir/diag.sh error-exit 1
+fi
+
+grep "message too long.*begin of message is:" rsyslog.out.log > /dev/null
+if [ $? -ne 0 ]; then
+        echo
+        echo "FAIL: expected message not found. rsyslog.out.log is:"
+        cat rsyslog.out.log
+        . $srcdir/diag.sh error-exit 1
+fi
+
+
+. $srcdir/diag.sh exit

--- a/tests/glbl-oversizeMsg-truncate.sh
+++ b/tests/glbl-oversizeMsg-truncate.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# add 2018-05-02 by PascalWithopf, released under ASL 2.0
+. $srcdir/diag.sh init
+./have_relpSrvSetOversizeMode
+if [ $? -eq 1 ]; then
+  echo "imrelp parameter oversizeMode not available. Test stopped"
+  exit 77
+fi;
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imrelp/.libs/imrelp")
+global(maxMessageSize="230")
+
+
+input(type="imrelp" port="13514" maxdatasize="300")
+
+template(name="outfmt" type="string" string="%rawmsg%\n")
+action(type="omfile" template="outfmt"
+				 file="rsyslog.out.log")
+'
+# TODO: add tcpflood option to specific EXACT test message size!
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh tcpflood -Trelp-plain -p13514 -m1 -d 240
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown
+
+# We need the ^-sign to symbolize the beginning and the $-sign to symbolize the end
+# because otherwise we won't know if it was truncated at the right length.
+grep "^<167>Mar  1 01:00:00 172.20.245.8 tag msgnum:00000000:240:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX$" rsyslog.out.log > /dev/null
+if [ $? -ne 0 ]; then
+        echo
+        echo "FAIL: expected message not found. rsyslog.out.log is:"
+        cat rsyslog.out.log
+        . $srcdir/diag.sh error-exit 1
+fi
+
+grep "message too long.*begin of message is:" rsyslog.out.log > /dev/null
+if [ $? -ne 0 ]; then
+        echo
+        echo "FAIL: expected message not found. rsyslog.out.log is:"
+        cat rsyslog.out.log
+        . $srcdir/diag.sh error-exit 1
+fi
+
+
+. $srcdir/diag.sh exit

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1044,7 +1044,7 @@ submitMsg2(smsg_t *pMsg)
 			getRawMsgLen(pMsg), glblGetMaxLine(), rawmsg);
 		writeOversizeMessageLog(pMsg);
 		// TODO: add config param
-		if(1) {
+		if(glblGetOversizeMsgInputMode()) {
 			splitOversizeMessage(pMsg);
 			/* we have submitted the message segments recursively, so we
 			 * can just deleted the original msg object and terminate.


### PR DESCRIPTION
Parameter is used to specify the mode with which
oversized messages will be handled.