### PR TITLE
change tests because of new error message truncation

### DIFF
--- a/tests/imptcp-msg-truncation-on-number.sh
+++ b/tests/imptcp-msg-truncation-on-number.sh
@@ -19,7 +19,7 @@ action(type="omfile" file="rsyslog.out.log")
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
 
-grep "Framing Error.*change to octet stuffing" rsyslog.out.log > /dev/null
+grep "Framing Error.*frame too large.*change to oc" rsyslog.out.log > /dev/null
 if [ $? -ne 0 ]; then
         echo
         echo "FAIL: expected error message from imptcp truncation not found. rsyslog.out.log is:"

--- a/tests/imptcp-oversize-message-display.sh
+++ b/tests/imptcp-oversize-message-display.sh
@@ -17,7 +17,7 @@ action(type="omfile" file="rsyslog.out.log")
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
 
-grep "imptcp:.*150.*\"ghijklmn test8 test9 test10 test\"" rsyslog.out.log > /dev/null
+grep "imptcp: message received.*150 byte larger.*will be split.*\"ghijkl" rsyslog.out.log > /dev/null
 if [ $? -ne 0 ]; then
         echo
         echo "FAIL: expected error message from imptcp truncation not found. rsyslog.out.log is:"
@@ -25,7 +25,7 @@ if [ $? -ne 0 ]; then
         . $srcdir/diag.sh error-exit 1
 fi
 
-grep "imptcp:.*22.*\"sstetstetsytetestetste\"" rsyslog.out.log > /dev/null
+grep "imptcp: message received.*22 byte larger.*will be split.*\"sstets" rsyslog.out.log > /dev/null
 if [ $? -ne 0 ]; then
         echo
         echo "FAIL: expected error message from imptcp truncation not found. rsyslog.out.log is:"


### PR DESCRIPTION
Error messages are truncated if they are to long.
Tests were corrected to only check for the available part.