### PR TITLE
mmnormalize: add tests for parsesuccess

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -626,7 +626,10 @@ if ENABLE_MMNORMALIZE
 TESTS += msgvar-concurrency-array.sh \
 	msgvar-concurrency-array-event.tags.sh \
 	mmnormalize_rule_from_string.sh \
-	mmnormalize_rule_from_array.sh
+	mmnormalize_rule_from_array.sh \
+	mmnormalize_parsesuccess_fail.sh \
+	mmnormalize_parsesuccess_fail2.sh \
+	mmnormalize_parsesuccess_ok.sh
 
 if ENABLE_IMPTCP
 TESTS +=  \
@@ -1165,6 +1168,11 @@ EXTRA_DIST= \
 	mmrm1stspace-basic.sh \
 	mmnormalize_rule_from_string.sh \
 	mmnormalize_rule_from_array.sh \
+	mmnormalize_parsesuccess_fail.sh \
+	testsuites/mmnormalize_parsesuccess_fail.sh \
+	mmnormalize_parsesuccess_fail2.sh \
+	testsuites/mmnormalize_parsesuccess_fail2.sh \
+	mmnormalize_parsesuccess_ok.sh \
 	pmnull-basic.sh \
 	pmnull-withparams.sh \
 	omstdout-basic.sh \

--- a/tests/mmnormalize_parsesuccess_fail.sh
+++ b/tests/mmnormalize_parsesuccess_fail.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# add 2018-05-11 by Pascal Withopf, released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../plugins/mmnormalize/.libs/mmnormalize")
+input(type="imtcp" port="13514" ruleset="tcpinput")
+
+template(name="outfmt" type="string" string="data: %$!data%, parsesuccess: %$!parsesuccess%\n")
+
+ruleset(name="tcpinput") {
+	action(name="main_cee_parser" type="mmnormalize" useRawMsg="off"
+		rulebase="testsuites/mmnormalize_parsesuccess_fail.rulebase")
+	set $!parsesuccess = $parsesuccess;
+	action(type="omfile" template="outfmt" file="rsyslog.out.log")	
+}
+'
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh tcpflood -m2 -M "\"message without json\""
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+
+echo 'data: , parsesuccess: FAIL
+data: , parsesuccess: FAIL' | cmp - rsyslog.out.log
+if [ ! $? -eq 0 ]; then
+  echo "invalid response generated, rsyslog.out.log is:"
+  cat rsyslog.out.log
+  . $srcdir/diag.sh error-exit  1
+fi;
+
+. $srcdir/diag.sh exit

--- a/tests/mmnormalize_parsesuccess_fail2.sh
+++ b/tests/mmnormalize_parsesuccess_fail2.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# add 2018-05-11 by Pascal Withopf, released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../plugins/mmnormalize/.libs/mmnormalize")
+input(type="imtcp" port="13514" ruleset="tcpinput")
+
+template(name="outfmt" type="string" string="data: %$!data%, parsesuccess: %$!parsesuccess%\n")
+
+ruleset(name="tcpinput") {
+	action(name="main_cee_parser" type="mmnormalize" useRawMsg="off"
+		rulebase="testsuites/mmnormalize_parsesuccess_fail2.rulebase")
+	set $!parsesuccess = $parsesuccess;
+	action(type="omfile" template="outfmt" file="rsyslog.out.log")	
+}
+'
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh tcpflood -m2 -M "\"message without json\""
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+
+echo 'data: , parsesuccess: FAIL
+data: , parsesuccess: FAIL' | cmp - rsyslog.out.log
+if [ ! $? -eq 0 ]; then
+  echo "invalid response generated, rsyslog.out.log is:"
+  cat rsyslog.out.log
+  . $srcdir/diag.sh error-exit  1
+fi;
+
+. $srcdir/diag.sh exit

--- a/tests/mmnormalize_parsesuccess_ok.sh
+++ b/tests/mmnormalize_parsesuccess_ok.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# add 2016-11-22 by Pascal Withopf, released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../plugins/mmnormalize/.libs/mmnormalize")
+input(type="imtcp" port="13514" ruleset="tcpinput")
+
+template(name="outfmt" type="string" string="data: %$!data%, parsesuccess: %$!parsesuccess%\n")
+
+ruleset(name="tcpinput") {
+	action(name="main_cee_parser" type="mmnormalize" useRawMsg="off"
+		rule="rule=:%data:json%")
+	set $!parsesuccess = $parsesuccess;
+	action(type="omfile" template="outfmt" file="rsyslog.out.log")	
+}
+'
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh tcpflood -m2 -M "\"{\\\"field\\\": \\\"data\\\"}\""
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+
+echo 'data: { "field": "data" }, parsesuccess: OK
+data: { "field": "data" }, parsesuccess: OK' | cmp - rsyslog.out.log
+if [ ! $? -eq 0 ]; then
+  echo "invalid response generated, rsyslog.out.log is:"
+  cat rsyslog.out.log
+  . $srcdir/diag.sh error-exit  1
+fi;
+
+. $srcdir/diag.sh exit

--- a/tests/testsuites/mmnormalize_parsesuccess_fail.rulebase
+++ b/tests/testsuites/mmnormalize_parsesuccess_fail.rulebase
@@ -1,0 +1,1 @@
+rule=:%data:json%

--- a/tests/testsuites/mmnormalize_parsesuccess_fail2.rulebase
+++ b/tests/testsuites/mmnormalize_parsesuccess_fail2.rulebase
@@ -1,0 +1,2 @@
+version=2
+rule=:%data:json%


### PR DESCRIPTION
Parsesuccess always is "OK" when using a rulebase with version 1,
even if it wasn't successfull.
These are tests to reproduce the issue.

See https://github.com/rsyslog/rsyslog/issues/2462

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
