### PR TITLE
TEST - DO NOT MERGE testbench: do test error reporting only if requested

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ compiler:
 
 env:
   global:
-    secure: DsTuVAZg5omWT652Xnz/ZG20nJ5ShdTDXPQA01HscUhjAzcuMYsCPp889QoLip+3O5yYH6/oH2WprQA6ZQQMt+7idNRo6ennu7tPQiHEBm/lK2Yq1W6r6tOb1zmSalbIVWV2cGTdKOOuHAatgmp/L70WjOlCrtLvPT+JQ9AkzLU=
+    - secure: DsTuVAZg5omWT652Xnz/ZG20nJ5ShdTDXPQA01HscUhjAzcuMYsCPp889QoLip+3O5yYH6/oH2WprQA6ZQQMt+7idNRo6ennu7tPQiHEBm/lK2Yq1W6r6tOb1zmSalbIVWV2cGTdKOOuHAatgmp/L70WjOlCrtLvPT+JQ9AkzLU=
+    - RSYSLOG_STATSURL="http://build.rsyslog.com/testbench-failedtest.php"
 
 addons:
   apt:

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -709,7 +709,10 @@ function error_exit() {
 
 # Helper function to call Adiscon test error script
 function error_stats() {
-	wget $RSYSLOG_STATSURL\?Testname=$RSYSLOG_TESTNAME\&Testenv=$PWD\&Testmachine=$HOSTNAME\&rndstr=jnxv8i34u78fg23
+	if [ "$RSYSLOG_STATSURL" != "" ]; then
+		echo reporting failure to $RSYSLOG_STATSURL
+		wget -nv $RSYSLOG_STATSURL\?Testname=$RSYSLOG_TESTNAME\&Testenv=$PWD\&Testmachine=$HOSTNAME\&rndstr=jnxv8i34u78fg23
+	fi
 }
 
 # do the usual sequence check to see if everything was properly received.
@@ -1306,7 +1309,6 @@ case $1 in
 
 		# Extra Variables for Test statistic reporting
 		export RSYSLOG_TESTNAME=$(basename $0)
-		export RSYSLOG_STATSURL="http://build.rsyslog.com/testbench-failedtest.php"
 
 		# we create one file with the test name, so that we know what was
 		# left over if "make distcheck" complains


### PR DESCRIPTION
the newly introduced test status reporting now always tries to connect
to our stats server. This can be considered a privacy invasion and
also can wreck our stats. so make this optional and only happen when
an explicit URL is given. This can than be set in our CI environment.

request by setting stats reporting url env var RSYSLOG_STATSURL

closes https://github.com/rsyslog/rsyslog/issues/3144

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
