### PR TITLE
Fix incorrect parameter comment in parsSkipWhitespace

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -208,8 +208,6 @@ rsRetVal parsSkipAfterChar(rsParsObj *pThis, char c)
 /* Skip whitespace. Often used to trim parsable entries.
  * Returns with ParsePointer set to first non-whitespace
  * character (or at end of string).
- * If bRequireOne is set to true, at least one whitespace
- * must exist, else an error is returned.
  */
 rsRetVal parsSkipWhitespace(rsParsObj *pThis)
 {


### PR DESCRIPTION
## Summary
- remove reference to nonexistent `bRequireOne` parameter

## Testing
- `make check TESTS='imfile-basic.sh'` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_68408a78298c83329e0f7ad21b4b5557