### PR TITLE
Optimize CI triggers

### DIFF
--- a/.github/workflows/ci.yml.template
+++ b/.github/workflows/ci.yml.template
@@ -26,6 +26,10 @@ name: CI PR runner
 
 on:
   pull_request:
+    paths-ignore:
+      - 'ChangeLog'
+      - '**/*.md'
+      - '**/*.txt'
 
 jobs:
   container_checks:

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -26,6 +26,10 @@ name: compile check
 
 on:
   pull_request:
+    paths-ignore:
+      - 'ChangeLog'
+      - '**/*.md'
+      - '**/*.txt'
 
 jobs:
   run:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,16 @@ name: "CodeQL"
 on:
   push:
     branches: [ "master" ]
+    paths-ignore:
+      - 'ChangeLog'
+      - '**/*.md'
+      - '**/*.txt'
   pull_request:
     branches: [ "master" ]
+    paths-ignore:
+      - 'ChangeLog'
+      - '**/*.md'
+      - '**/*.txt'
   schedule:
     - cron: "38 1 * * 3"
 

--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -26,6 +26,10 @@ name: check
 
 on:
   pull_request:
+    paths-ignore:
+      - 'ChangeLog'
+      - '**/*.md'
+      - '**/*.txt'
 
 jobs:
   CI:

--- a/.github/workflows/run_journal.yml
+++ b/.github/workflows/run_journal.yml
@@ -26,6 +26,10 @@ name: check systemd journal
 
 on:
   pull_request:
+    paths-ignore:
+      - 'ChangeLog'
+      - '**/*.md'
+      - '**/*.txt'
 
 jobs:
   check_run:

--- a/.github/workflows/run_kafka_distcheck.yml
+++ b/.github/workflows/run_kafka_distcheck.yml
@@ -26,6 +26,10 @@ name: check kafka distcheck
 
 on:
   pull_request:
+    paths-ignore:
+      - 'ChangeLog'
+      - '**/*.md'
+      - '**/*.txt'
 
 jobs:
   check_run:


### PR DESCRIPTION
## Summary
- skip expensive GitHub Actions if only documentation-like files changed

## Testing
- `yamllint .github/workflows` *(fails: line length errors)*

------
https://chatgpt.com/codex/tasks/task_e_684471cf0bd08332ab0d158d161d5e5c