### PR TITLE
omsendertrack: handle missing statefile

### DIFF
--- a/plugins/omsendertrack/omsendertrack.c
+++ b/plugins/omsendertrack/omsendertrack.c
@@ -470,8 +470,14 @@ writeSenderInfo(instanceData *const pData)
 {
     DEFiRet;
     FILE *fp = NULL;
-    const char *tmpname = (const char *)pData->statefile_tmp;
+    const char *tmpname;
     int tmp_alloc = 0;
+
+    if (pData == NULL || pData->statefile == NULL) {
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+
+    tmpname = (const char *)pData->statefile_tmp;
 
     dbgprintf("writeSenderInfo, file %s\n", pData->statefile);
     if (tmpname == NULL) {
@@ -671,7 +677,9 @@ BEGINfreeInstance
     }
 
     /* do final write */
-    writeSenderInfo(pData);
+    if (pData->statefile != NULL) {
+        writeSenderInfo(pData);
+    }
 
     /* destroy data structs */
     free((void *)pData->senderidTemplate);


### PR DESCRIPTION
## Summary
- avoid NULL dereference in writeSenderInfo by aborting when no statefile is configured
- skip final persistence when statefile is absent during instance cleanup

## Testing
- `devtools/format-code.sh`
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68af2ae44a448332aec9ab7f7a94c600