### PR TITLE
github: cancel superseded workflow runs

### DIFF
--- a/.github/workflows/ci.yml.template
+++ b/.github/workflows/ci.yml.template
@@ -31,6 +31,10 @@ on:
       - '**/*.md'
       - '**/*.txt'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   container_checks:
     runs-on: ubuntu-18.04

--- a/.github/workflows/ci_codestyle_check.yml
+++ b/.github/workflows/ci_codestyle_check.yml
@@ -3,6 +3,10 @@ name: "Code Style Check"
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   style-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -27,6 +27,10 @@ name: compile check
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,10 @@ on:
   schedule:
     - cron: "38 1 * * 3"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/commit_style_check.yml
+++ b/.github/workflows/commit_style_check.yml
@@ -15,6 +15,10 @@ name: PR Validation
 on:
   pull_request: # Defaults to opened, synchronize, reopened
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-pr:
     runs-on: ubuntu-latest # 'ubuntu-latest' provides a virtual machine with the latest Ubuntu OS.

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -6,6 +6,10 @@ name: documentation build
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -25,7 +25,7 @@
 name: check
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/run_journal.yml
+++ b/.github/workflows/run_journal.yml
@@ -32,6 +32,10 @@ on:
       - '**/*.txt'
       - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check_run:
     runs-on: ubuntu-24.04

--- a/.github/workflows/run_kafka_distcheck.yml
+++ b/.github/workflows/run_kafka_distcheck.yml
@@ -32,6 +32,10 @@ on:
       - '**/*.txt'
       - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check_run:
     runs-on: ubuntu-latest

--- a/.github/workflows/yaml_lint.yml
+++ b/.github/workflows/yaml_lint.yml
@@ -20,6 +20,10 @@ name: yamllint check
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add cancel-in-progress concurrency group to PR workflows so new pushes abort outdated jobs

## Testing
- `yamllint -d '{extends: default, rules: {line-length: disable, truthy: disable, colons: disable, comments: disable, document-start: disable, empty-lines: disable, brackets: disable}}' .github/workflows/ci.yml.template .github/workflows/ci_codestyle_check.yml .github/workflows/ci_compile.yml .github/workflows/clang-analyzer.yml .github/workflows/codeql.yml .github/workflows/commit_style_check.yml .github/workflows/doc_build.yml .github/workflows/run_checks.yml .github/workflows/run_journal.yml .github/workflows/run_kafka_distcheck.yml .github/workflows/yaml_lint.yml`
- `./devtools/format-code.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b02674a8f483328b747fc60dc65dbd