### PR TITLE
omkafka: allow sending static headers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2492,8 +2492,8 @@ AM_CONDITIONAL(ENABLE_KAFKA_STATIC, test x$enable_kafka_static = xyes)
 # omkafka works with older library
 omkafka_use_dummy="no"
 if test "$enable_omkafka" = "yes" -o "$enable_omkafka" = "optional"; then
-	PKG_CHECK_MODULES([LIBRDKAFKA], [rdkafka >= 0.9.1],, [
-		PKG_CHECK_MODULES([LIBRDKAFKA], [librdkafka],, [
+        PKG_CHECK_MODULES([LIBRDKAFKA], [rdkafka >= 0.11.0],, [
+                PKG_CHECK_MODULES([LIBRDKAFKA], [librdkafka],, [
 			AC_CHECK_LIB([rdkafka], [rd_kafka_last_error], [
 				AC_MSG_WARN([librdkafka is missing but library present, using -lrdkafka])
 				LIBRDKAFKA_LIBS=-lrdkafka
@@ -2528,7 +2528,7 @@ fi
 imkafka_use_dummy="no"
 # imkafka needs newer library
 if test "x$enable_imkafka" = "xyes" -o "$enable_imkafka" = "optional"; then
-	PKG_CHECK_MODULES([LIBRDKAFKA], [rdkafka >= 0.9.1],, [
+        PKG_CHECK_MODULES([LIBRDKAFKA], [rdkafka >= 0.11.0],, [
 		AC_CHECK_LIB([rdkafka], [rd_kafka_consumer_poll], [
 			AC_MSG_WARN([librdkafka is missing but library present, using -lrdkafka])
 			LIBRDKAFKA_LIBS=-lrdkafka

--- a/doc/source/configuration/modules/omkafka.rst
+++ b/doc/source/configuration/modules/omkafka.rst
@@ -39,6 +39,7 @@ Configuration Parameters
    ../../reference/parameters/omkafka-statsfile
    ../../reference/parameters/omkafka-confparam
    ../../reference/parameters/omkafka-topicconfparam
+   ../../reference/parameters/omkafka-kafkaheader
    ../../reference/parameters/omkafka-template
    ../../reference/parameters/omkafka-closetimeout
    ../../reference/parameters/omkafka-resubmitonfailure
@@ -105,6 +106,10 @@ Action Parameters
         :end-before: .. summary-end
    * - :ref:`param-omkafka-topicconfparam`
      - .. include:: ../../reference/parameters/omkafka-topicconfparam.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omkafka-kafkaheader`
+     - .. include:: ../../reference/parameters/omkafka-kafkaheader.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
    * - :ref:`param-omkafka-template`

--- a/doc/source/reference/parameters/omkafka-kafkaheader.rst
+++ b/doc/source/reference/parameters/omkafka-kafkaheader.rst
@@ -1,0 +1,44 @@
+.. _param-omkafka-kafkaheader:
+.. _omkafka.parameter.module.kafkaheader:
+
+KafkaHeader
+===========
+
+.. index::
+   single: omkafka; KafkaHeader
+   single: KafkaHeader
+
+.. summary-start
+
+Defines Kafka message headers to attach to each produced message. Each entry is a `key=value` pair.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omkafka`.
+
+:Name: KafkaHeader
+:Scope: action
+:Type: array[string]
+:Default: action=none
+:Required?: no
+:Introduced: 8.2405.0
+
+Description
+-----------
+
+Specifies static headers that are added to every message sent to Kafka. The parameter accepts an array of `key=value` strings.
+
+Action usage
+------------
+
+.. code-block:: rsyslog
+
+   action(type="omkafka"
+          topic="mytopic"
+          broker="localhost:9092"
+          kafkaHeader=["foo=bar","answer=42"])
+
+See also
+--------
+
+* :doc:`../../configuration/modules/omkafka`

--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -39,6 +39,10 @@
 #include <unistd.h>
 #include <librdkafka/rdkafka.h>
 
+#if RD_KAFKA_VERSION < 0x000b0000
+    #error "omkafka requires librdkafka v0.11 or later"
+#endif
+
 #include "rsyslog.h"
 #include "syslogd-types.h"
 #include "srUtils.h"
@@ -225,6 +229,8 @@ typedef struct _instanceData {
     struct kafka_params *confParams;
     int nTopicConfParams;
     struct kafka_params *topicConfParams;
+    int nHeaders;
+    struct kafka_params *headers;
     uchar *errorFile;
     uchar *key;
     int bReopenOnHup;
@@ -278,6 +284,7 @@ static struct cnfparamdescr actpdescr[] = {
     {"broker", eCmdHdlrArray, 0},
     {"confparam", eCmdHdlrArray, 0},
     {"topicconfparam", eCmdHdlrArray, 0},
+    {"kafkaheader", eCmdHdlrArray, 0},
     {"errorfile", eCmdHdlrGetWord, 0},
     {"statsfile", eCmdHdlrGetWord, 0},
     {"key", eCmdHdlrGetWord, 0},
@@ -813,21 +820,30 @@ static rsRetVal ATTR_NONNULL(1, 3) writeKafka(instanceData *const pData,
     }
     DBGPRINTF("omkafka: rd_kafka_producev timestamp=%s/%" PRId64 "\n", msgTimestamp, ttMsgTimestamp);
 
+    rd_kafka_headers_t *headers = NULL;
+    if (pData->nHeaders > 0) {
+        headers = rd_kafka_headers_new(pData->nHeaders);
+        for (int i = 0; i < pData->nHeaders; ++i) {
+            rd_kafka_header_add(headers, pData->headers[i].name, -1, pData->headers[i].val, -1);
+        }
+    }
+
     /* Using new kafka producev API, includes Timestamp! */
     if (key == NULL) {
-        msg_kafka_response =
-            rd_kafka_producev(pData->rk, RD_KAFKA_V_RKT(rkt), RD_KAFKA_V_PARTITION(partition),
-                              RD_KAFKA_V_VALUE(msg, strlen((char *)msg)), RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
-                              RD_KAFKA_V_TIMESTAMP(ttMsgTimestamp), RD_KAFKA_V_KEY(NULL, 0), RD_KAFKA_V_END);
+        msg_kafka_response = rd_kafka_producev(
+            pData->rk, RD_KAFKA_V_RKT(rkt), RD_KAFKA_V_PARTITION(partition), RD_KAFKA_V_VALUE(msg, strlen((char *)msg)),
+            RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY), RD_KAFKA_V_TIMESTAMP(ttMsgTimestamp), RD_KAFKA_V_KEY(NULL, 0),
+            RD_KAFKA_V_HEADERS(headers), RD_KAFKA_V_END);
     } else {
         DBGPRINTF("omkafka: rd_kafka_producev key=%s\n", key);
         msg_kafka_response = rd_kafka_producev(
             pData->rk, RD_KAFKA_V_RKT(rkt), RD_KAFKA_V_PARTITION(partition), RD_KAFKA_V_VALUE(msg, strlen((char *)msg)),
             RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY), RD_KAFKA_V_TIMESTAMP(ttMsgTimestamp),
-            RD_KAFKA_V_KEY(key, strlen((char *)key)), RD_KAFKA_V_END);
+            RD_KAFKA_V_KEY(key, strlen((char *)key)), RD_KAFKA_V_HEADERS(headers), RD_KAFKA_V_END);
     }
 
     if (msg_kafka_response != RD_KAFKA_RESP_ERR_NO_ERROR) {
+        if (headers != NULL) rd_kafka_headers_destroy(headers);
         updateKafkaFailureCounts(msg_kafka_response);
 
         /* Put into kafka queue, again if configured! */
@@ -1656,6 +1672,11 @@ BEGINfreeInstance
         free((void *)pData->topicConfParams[i].val);
     }
     free(pData->topicConfParams);
+    for (int i = 0; i < pData->nHeaders; ++i) {
+        free((void *)pData->headers[i].name);
+        free((void *)pData->headers[i].val);
+    }
+    free(pData->headers);
     DESTROY_ATOMIC_HELPER_MUT(pData->mutCurrPartition);
     pthread_rwlock_destroy(&pData->rkLock);
     pthread_mutex_destroy(&pData->mut_doAction);
@@ -1810,6 +1831,8 @@ static void setInstParamDefaults(instanceData *pData) {
     pData->confParams = NULL;
     pData->nTopicConfParams = 0;
     pData->topicConfParams = NULL;
+    pData->nHeaders = 0;
+    pData->headers = NULL;
     pData->errorFile = NULL;
     pData->statsFile = NULL;
     pData->failedMsgFile = NULL;
@@ -1889,6 +1912,14 @@ BEGINnewActInst
             for (int j = 0; j < pvals[i].val.d.ar->nmemb; ++j) {
                 char *cstr = es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);
                 CHKiRet(processKafkaParam(cstr, &pData->topicConfParams[j].name, &pData->topicConfParams[j].val));
+                free(cstr);
+            }
+        } else if (!strcmp(actpblk.descr[i].name, "kafkaheader")) {
+            pData->nHeaders = pvals[i].val.d.ar->nmemb;
+            CHKmalloc(pData->headers = malloc(sizeof(struct kafka_params) * pvals[i].val.d.ar->nmemb));
+            for (int j = 0; j < pvals[i].val.d.ar->nmemb; ++j) {
+                char *cstr = es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);
+                CHKiRet(processKafkaParam(cstr, &pData->headers[j].name, &pData->headers[j].val));
                 free(cstr);
             }
         } else if (!strcmp(actpblk.descr[i].name, "errorfile")) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1035,11 +1035,12 @@ if ENABLE_OMKAFKA
 if ENABLE_IMKAFKA
 if ENABLE_KAFKA_TESTS
 TESTS += \
-	kafka-selftest.sh \
-	omkafka.sh \
-	omkafkadynakey.sh \
-	imkafka.sh \
-	imkafka-backgrounded.sh \
+        kafka-selftest.sh \
+        omkafka.sh \
+        omkafkadynakey.sh \
+        omkafka-headers.sh \
+        imkafka.sh \
+        imkafka-backgrounded.sh \
 	imkafka-config-err-ruleset.sh \
 	imkafka-config-err-param.sh \
 	imkafka-hang-on-no-kafka.sh \
@@ -1065,13 +1066,14 @@ sndrcv_kafka.log: imkafka_multi_single.log
 imkafka_multi_group.log: sndrcv_kafka.log
 sndrcv_kafka_multi_topics.log: imkafka_multi_group.log
 omkafkadynakey.log: sndrcv_kafka_multi_topics.log
+omkafka-headers.log: omkafkadynakey.log
 
 if HAVE_VALGRIND
 TESTS += \
 	omkafka-vg.sh \
 	imkafka-vg.sh
 
-omkafka-vg.log: sndrcv_kafka_multi_topics.log
+omkafka-vg.log: omkafka-headers.log
 imkafka-vg.log: omkafka-vg.log
 endif
 endif

--- a/tests/omkafka-headers.sh
+++ b/tests/omkafka-headers.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+## @file omkafka-headers.sh
+## @brief Verify Kafka headers are produced by omkafka.
+# added 2024-05-05 by AI Assistant
+. ${srcdir:=.}/diag.sh init
+check_command_available kafkacat
+
+export KEEP_KAFKA_RUNNING="YES"
+export RANDTOPIC=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 8 | head -n 1)
+export EXTRA_EXITCHECK=dumpkafkalogs
+export EXTRA_EXIT=kafka
+
+download_kafka
+stop_zookeeper
+stop_kafka
+
+start_zookeeper
+start_kafka
+create_kafka_topic $RANDTOPIC '.dep_wrk' '22181'
+
+generate_conf
+add_conf '
+main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
+$imdiagInjectDelayMode full
+
+module(load="../plugins/omkafka/.libs/omkafka")
+
+template(name="outfmt" type="string" string="%msg%")
+local0.* action(
+    type="omkafka"
+    topic="'$RANDTOPIC'"
+    broker="localhost:29092"
+    kafkaHeader=["testkey=testvalue"]
+    template="outfmt"
+)
+'
+
+startup
+injectmsg 0 1
+
+kafkacat -b localhost:29092 -t $RANDTOPIC -C -c1 -f "%h\n" > "$RSYSLOG_OUT_LOG"
+shutdown_when_empty
+wait_shutdown
+
+grep -q "testkey=testvalue" "$RSYSLOG_OUT_LOG"
+exit $?


### PR DESCRIPTION
## Summary
- add `kafkaHeader` option to define static Kafka headers
- send configured headers with each message and require librdkafka >= 0.11
- document header option and test its presence

## Testing
- `autoreconf -i`
- `./configure --enable-omkafka --disable-imkafka`
- `make -j4`
- `./tests/omkafka-headers.sh` *(fails: Testbench requires unavailable command: kafkacat)*

------
https://chatgpt.com/codex/tasks/task_e_68b84c5f7b008332aefa677205da4805