### PR TITLE
imhttp: guard handler registration

### DIFF
--- a/contrib/imhttp/imhttp.c
+++ b/contrib/imhttp/imhttp.c
@@ -996,7 +996,9 @@ finalize:
 static int runloop(void) {
     dbgprintf("imhttp started.\n");
 
-    /* Add handler for form data */
+    /* Register handlers under context lock to avoid civetweb races */
+    mg_lock_context(s_httpserv->ctx);
+
     for (instanceConf_t *inst = runModConf->root; inst != NULL; inst = inst->next) {
         assert(inst->pszEndpoint);
         if (inst->pszEndpoint) {
@@ -1027,6 +1029,8 @@ static int runloop(void) {
                                 runModConf->pszMetricsAuthFile);
         }
     }
+
+    mg_unlock_context(s_httpserv->ctx);
 
     /* Wait until the server should be closed */
     while (glbl.GetGlobalInputTermState() == 0) {


### PR DESCRIPTION
## Summary
- protect civetweb handler registration with mg_lock_context to avoid races

## Testing
- `devtools/format-code.sh`
- `./configure --enable-imhttp`
- `make -C contrib/imhttp imhttp.la`


------
https://chatgpt.com/codex/tasks/task_e_68b9b276d2e0833291ecad5d90577bbc