### PR TITLE
misc: add void parameter lists

### DIFF
--- a/compat/asprintf.c
+++ b/compat/asprintf.c
@@ -47,6 +47,6 @@ int asprintf(char **strp, const char *fmt, ...) {
 #else
     /* XLC needs at least one method in source file even static to compile */
     #ifdef __xlc__
-static void dummy() {}
+static void dummy(void) {}
     #endif
 #endif /* #ifndef HAVE_ASPRINTF */

--- a/compat/strndup.c
+++ b/compat/strndup.c
@@ -40,6 +40,6 @@ char *strndup(const char *s, size_t n) {
 #else
     /* XLC needs at least one method in source file even static to compile */
     #ifdef __xlc__
-static void dummy() {}
+static void dummy(void) {}
     #endif
 #endif /* #ifndef HAVE_STRNDUP */

--- a/contrib/imkmsg/imkmsg.h
+++ b/contrib/imkmsg/imkmsg.h
@@ -59,7 +59,6 @@ rsRetVal klogLogKMsg(modConfData_t *pModConf);
 rsRetVal klogWillRunPrePrivDrop(modConfData_t *pModConf);
 rsRetVal klogWillRunPostPrivDrop(modConfData_t *pModConf);
 rsRetVal klogAfterRun(modConfData_t *pModConf);
-int klogFacilIntMsg();
 
 /* the functions below may be called by the drivers */
 rsRetVal imkmsgLogIntMsg(syslog_pri_t priority, const char *fmt, ...) __attribute__((format(printf, 2, 3)));

--- a/plugins/imklog/solaris_cddl.c
+++ b/plugins/imklog/solaris_cddl.c
@@ -169,7 +169,7 @@ int sun_openklog(char *name, int mode) {
 /*
  * Pull up one message from log driver.
  */
-void sun_getkmsg() {
+static void sun_getkmsg(void) {
     int flags = 0, i;
     char *lastline;
     struct strbuf ctl, dat;
@@ -249,7 +249,7 @@ void sun_getkmsg() {
  * thread.
  */
 /*ARGSUSED*/
-void *sun_sys_poll() {
+void *sun_sys_poll(void) {
     int nfds;
 
     dbgprintf("klog:sys_poll: sys_thread started\n");

--- a/plugins/imklog/solaris_cddl.h
+++ b/plugins/imklog/solaris_cddl.h
@@ -1,2 +1,2 @@
-void *sun_sys_poll();
+void *sun_sys_poll(void);
 int sun_openklog(char *name, int mode);

--- a/tests/diagtalker.c
+++ b/tests/diagtalker.c
@@ -112,7 +112,7 @@ static void waitRsp(int fd, char *buf, int len) {
 
 /* do the actual processing
  */
-static void doProcessing() {
+static void doProcessing(void) {
     int fd;
     int len;
     char line[2048];

--- a/tests/filewriter.c
+++ b/tests/filewriter.c
@@ -54,7 +54,7 @@ static int batchsize = 1000;
 
 /* read the input file and create in-memory representation
  */
-static void readFile() {
+static void readFile(void) {
     char *r;
     char lnBuf[10240];
     struct line *node;
@@ -89,7 +89,7 @@ static void readFile() {
 }
 
 
-static void genCopies() {
+static void genCopies(void) {
     long long i;
     long long unsigned lnnbr;
     struct line *node;

--- a/tests/inputfilegen.c
+++ b/tests/inputfilegen.c
@@ -53,7 +53,7 @@ static void hdlr_sighup(int sig) {
     fprintf(stderr, "inputfilegen: had hup, sig %d\n", sig);
     bHadHUP = 1;
 }
-static void sighup_enable() {
+static void sighup_enable(void) {
     struct sigaction sigAct;
     memset(&sigAct, 0, sizeof(sigAct));
     sigemptyset(&sigAct.sa_mask);

--- a/tests/randomgen.c
+++ b/tests/randomgen.c
@@ -55,7 +55,7 @@ static long long fileSize = 1024 * 1024; /* file size in K, 1MB default */
 /* generate the random file. This code really can be improved (e.g. read /dev/urandom
  * when available)
  */
-static void genFile() {
+static void genFile(void) {
     long i;
     FILE *fp;
     FILE *rfp = NULL;

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -989,7 +989,7 @@ static void *thrdStarter(void *arg) {
  * parameter blocks and starts threads. It returns when all threads are ready to run
  * and the main task must just enable them.
  */
-static void prepareGenerators() {
+static void prepareGenerators(void) {
     int i;
     long long msgsThrd;
     long long starting = 0;
@@ -1031,7 +1031,7 @@ static void prepareGenerators() {
 /* Let all generators run. Threads must have been started. Here we wait until
  * all threads are initialized and then broadcast that they can begin to run.
  */
-static void runGenerators() {
+static void runGenerators(void) {
     pthread_mutex_lock(&thrdMgmt);
     while (runningThreads != numThrds) {
         pthread_cond_wait(&condStarted, &thrdMgmt);
@@ -1044,7 +1044,7 @@ static void runGenerators() {
 
 /* Wait for all traffic generators to stop.
  */
-static void waitGenerators() {
+static void waitGenerators(void) {
     int i;
     for (i = 0; i < numThrds; ++i) {
         pthread_join(instarray[i].thread, NULL);
@@ -1568,7 +1568,7 @@ static void closeTLSSess(int i) {
 
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wint-to-pointer-cast"
-static void initDTLSSess() {
+static void initDTLSSess(void) {
     int res;
     BIO *bio_client;
 
@@ -1676,7 +1676,7 @@ static int sendDTLS(char *buf, size_t lenBuf) {
     return lenSent;
 }
 
-static void closeDTLSSess() {
+static void closeDTLSSess(void) {
     printf("closeDTLSSess ENTER\n");
 
     int r;

--- a/tools/rscryutil.c
+++ b/tools/rscryutil.c
@@ -415,10 +415,10 @@ static int gcryDoDecrypt(FILE __attribute__((unused)) * logfp,
                          FILE __attribute__((unused)) * outfp) {
     return 0;
 }
-static int rsgcryAlgoname2Algo() {
+static int rsgcryAlgoname2Algo(char *const __attribute__((unused)) algoname) {
     return 0;
 }
-static int rsgcryModename2Mode() {
+static int rsgcryModename2Mode(char *const __attribute__((unused)) modename) {
     return 0;
 }
 #endif


### PR DESCRIPTION
## Summary
- replace K&R-style empty parameter lists with explicit `void` declarations in compatibility stubs and test helpers
- remove redundant prototype and use explicit parameter list for internal function `klogFacilIntMsg`
- ensure Solaris CDDL polling helpers use explicit parameter lists and mark `sun_getkmsg` static

## Testing
- `devtools/format-code.sh`
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8629ca748332a12c42cd94c747c6