### PR TITLE
omhttp: allow configuring HTTP version

### DIFF
--- a/contrib/omhttp/omhttp.c
+++ b/contrib/omhttp/omhttp.c
@@ -143,6 +143,7 @@ typedef struct instanceConf_s {
     sbool useHttps;
     sbool allowUnsignedCerts;
     sbool skipVerifyHost;
+    long httpVersion;
     uchar *caCertFile;
     uchar *myCertFile;
     uchar *myPrivKeyFile;
@@ -232,6 +233,7 @@ static struct cnfparamdescr actpdescr[] = {
     {"compress", eCmdHdlrBinary, 0},
     {"compress.level", eCmdHdlrInt, 0},
     {"usehttps", eCmdHdlrBinary, 0},
+    {"httpversion", eCmdHdlrGetWord, 0},
     {"errorfile", eCmdHdlrGetWord, 0},
     {"template", eCmdHdlrGetWord, 0},
     {"allowunsignedcerts", eCmdHdlrBinary, 0},
@@ -1705,6 +1707,7 @@ static void ATTR_NONNULL() curlSetupCommon(wrkrInstanceData_t *const pWrkrData, 
     curl_easy_setopt(handle, CURLOPT_NOSIGNAL, TRUE);
     curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, curlResult);
     curl_easy_setopt(handle, CURLOPT_WRITEDATA, pWrkrData);
+    curl_easy_setopt(handle, CURLOPT_HTTP_VERSION, pWrkrData->pData->httpVersion);
     if (pWrkrData->pData->proxyHost != NULL) {
         curl_easy_setopt(handle, CURLOPT_PROXY, pWrkrData->pData->proxyHost);
     }
@@ -1833,6 +1836,7 @@ static void ATTR_NONNULL() setInstParamDefaults(instanceData *const pData) {
     pData->compressionLevel = -1;  // default compression
     pData->allowUnsignedCerts = 0;
     pData->skipVerifyHost = 0;
+    pData->httpVersion = CURL_HTTP_VERSION_NONE;
     pData->tplName = NULL;
     pData->errorFile = NULL;
     pData->caCertFile = NULL;
@@ -2056,6 +2060,19 @@ BEGINnewActInst
             pData->skipVerifyHost = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "usehttps")) {
             pData->useHttps = pvals[i].val.d.n;
+        } else if (!strcmp(actpblk.descr[i].name, "httpversion")) {
+            char *const version = es_str2cstr(pvals[i].val.d.estr, NULL);
+            if (!strcmp(version, "auto")) {
+                pData->httpVersion = CURL_HTTP_VERSION_NONE;
+            } else if (!strcmp(version, "1.1")) {
+                pData->httpVersion = CURL_HTTP_VERSION_1_1;
+            } else if (!strcmp(version, "2")) {
+                pData->httpVersion = CURL_HTTP_VERSION_2_0;
+            } else {
+                LogError(0, NO_ERRCODE, "error: 'httpversion' %s unknown defaulting to 'auto'", version);
+                pData->httpVersion = CURL_HTTP_VERSION_NONE;
+            }
+            free(version);
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
             pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
         } else if (!strcmp(actpblk.descr[i].name, "tls.cacert")) {

--- a/doc/source/configuration/modules/omhttp.rst
+++ b/doc/source/configuration/modules/omhttp.rst
@@ -536,6 +536,19 @@ useHttps
 
 When switched to "on" you will use `https` instead of `http`.
 
+httpversion
+^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "word", "auto", "no", "none"
+
+Selects the HTTP protocol version libcurl should use. ``auto`` lets
+libcurl negotiate the best version. ``1.1`` forces HTTP/1.1 and ``2``
+forces HTTP/2. The default is ``auto``.
 
 tls.cacert
 ^^^^^^^^^^

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1012,12 +1012,14 @@ TESTS +=  \
 	omhttp-batch-lokirest.sh \
 	omhttp-profile-loki.sh \
 	omhttp-batch-newline.sh \
-	omhttp-retry.sh \
-	omhttp-retry-timeout.sh \
-	omhttp-httpheaderkey.sh \
-	omhttp-multiplehttpheaders.sh \
-	omhttp-dynrestpath.sh \
-	omhttp-batch-dynrestpath.sh
+        omhttp-retry.sh \
+        omhttp-retry-timeout.sh \
+        omhttp-httpheaderkey.sh \
+        omhttp-multiplehttpheaders.sh \
+        omhttp-httpversion-1.1.sh \
+        omhttp-httpversion-2.sh \
+        omhttp-dynrestpath.sh \
+        omhttp-batch-dynrestpath.sh
 if HAVE_VALGRIND
 TESTS +=  \
 	omhttp-auth-vg.sh \
@@ -2765,16 +2767,18 @@ EXTRA_DIST= \
 	omhttp-batch-newline.sh \
 	omhttp-batch-retry-metadata.sh \
 	omhttp-retry-timeout.sh \
-	omhttp-basic-ignorecodes-vg.sh \
-	omhttp-batch-retry-metadata-vg.sh \
-	omhttp-retry-timeout-vg.sh \
-	omhttp-retry.sh \
-	omhttp-httpheaderkey.sh \
-	omhttp-multiplehttpheaders.sh \
-	omhttp-dynrestpath.sh \
-	omhttp-batch-dynrestpath.sh \
-	omhttp-auth-vg.sh \
-	omhttp-basic-vg.sh \
+        omhttp-basic-ignorecodes-vg.sh \
+        omhttp-batch-retry-metadata-vg.sh \
+        omhttp-retry-timeout-vg.sh \
+        omhttp-retry.sh \
+        omhttp-httpheaderkey.sh \
+        omhttp-multiplehttpheaders.sh \
+        omhttp-httpversion-1.1.sh \
+        omhttp-httpversion-2.sh \
+        omhttp-dynrestpath.sh \
+        omhttp-batch-dynrestpath.sh \
+        omhttp-auth-vg.sh \
+        omhttp-basic-vg.sh \
 	omhttp-batch-jsonarray-compress-vg.sh \
 	omhttp-batch-jsonarray-retry-vg.sh \
 	omhttp-batch-jsonarray-vg.sh \

--- a/tests/omhttp-httpversion-1.1.sh
+++ b/tests/omhttp-httpversion-1.1.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+
+#  Starting actual testbench
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=100
+
+omhttp_start_server 0
+
+generate_conf
+add_conf '
+template(name="tpl" type="string"
+         string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+module(load="../contrib/omhttp/.libs/omhttp")
+
+if $msg contains "msgnum:" then
+        action(
+                # Payload
+                name="my_http_action"
+                type="omhttp"
+                errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
+                template="tpl"
+
+                server="localhost"
+                serverport="'$omhttp_server_lstnport'"
+                restpath="my/endpoint"
+                batch="off"
+                httpversion="1.1"
+                usehttps="off"
+    )
+'
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+omhttp_get_data $omhttp_server_lstnport my/endpoint
+omhttp_stop_server
+seq_check
+exit_test
+

--- a/tests/omhttp-httpversion-2.sh
+++ b/tests/omhttp-httpversion-2.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+
+#  Starting actual testbench
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=100
+
+omhttp_start_server 0
+
+generate_conf
+add_conf '
+template(name="tpl" type="string"
+         string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+module(load="../contrib/omhttp/.libs/omhttp")
+
+if $msg contains "msgnum:" then
+        action(
+                # Payload
+                name="my_http_action"
+                type="omhttp"
+                errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
+                template="tpl"
+
+                server="localhost"
+                serverport="'$omhttp_server_lstnport'"
+                restpath="my/endpoint"
+                batch="off"
+                httpversion="2"
+                usehttps="off"
+    )
+'
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+omhttp_get_data $omhttp_server_lstnport my/endpoint
+omhttp_stop_server
+if [ -s "$RSYSLOG_DYNNAME/omhttp.error.log" ]; then
+    exit_test
+else
+    echo "expected HTTP/2 request to fail" >&2
+    error_exit 1
+fi
+


### PR DESCRIPTION
## Summary
- add `httpversion` action parameter (auto|1.1|2)
- apply `CURLOPT_HTTP_VERSION` based on configuration
- document new option and add tests for forcing HTTP versions

## Testing
- `devtools/format-code.sh`
- `./autogen.sh`
- `./configure`
- `make -C contrib/omhttp`
- `make -j4` *(failed: No rule to make target 'all')*
- `tests/omhttp-httpversion-1.1.sh` *(failed: make check failed)*
- `tests/omhttp-httpversion-2.sh` *(failed: ../tools/rsyslogd: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d71128e88332ac187f29bf196a82