### PR TITLE
doc: document omelasticsearch error logging flags

### DIFF
--- a/doc/source/configuration/modules/omelasticsearch.rst
+++ b/doc/source/configuration/modules/omelasticsearch.rst
@@ -132,6 +132,14 @@ Action Parameters
      - .. include:: ../../reference/parameters/omelasticsearch-errorfile.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-erroronly`
+     - .. include:: ../../reference/parameters/omelasticsearch-erroronly.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-interleaved`
+     - .. include:: ../../reference/parameters/omelasticsearch-interleaved.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`param-omelasticsearch-tls-cacert`
      - .. include:: ../../reference/parameters/omelasticsearch-tls-cacert.rst
         :start-after: .. summary-start
@@ -212,6 +220,8 @@ Action Parameters
    ../../reference/parameters/omelasticsearch-uid
    ../../reference/parameters/omelasticsearch-pwd
    ../../reference/parameters/omelasticsearch-errorfile
+   ../../reference/parameters/omelasticsearch-erroronly
+   ../../reference/parameters/omelasticsearch-interleaved
    ../../reference/parameters/omelasticsearch-tls-cacert
    ../../reference/parameters/omelasticsearch-tls-mycert
    ../../reference/parameters/omelasticsearch-tls-myprivkey

--- a/doc/source/reference/parameters/omelasticsearch-erroronly.rst
+++ b/doc/source/reference/parameters/omelasticsearch-erroronly.rst
@@ -1,0 +1,44 @@
+.. _param-omelasticsearch-erroronly:
+.. _omelasticsearch.parameter.module.erroronly:
+
+erroronly
+=========
+
+.. index::
+   single: omelasticsearch; erroronly
+   single: erroronly
+
+.. summary-start
+
+Record only failed bulk operations in the configured error file.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: erroronly
+:Scope: action
+:Type: boolean
+:Default: action=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Enabling ``erroronly`` limits the contents of :ref:`param-omelasticsearch-errorfile`
+to bulk requests that Elasticsearch reported as failed. Successful operations are
+ignored, keeping the error log focused on actionable records. When combined with
+:ref:`param-omelasticsearch-interleaved`, the module still filters for failures
+but stores them as request/response pairs.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-erroronly:
+.. _omelasticsearch.parameter.action.erroronly:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" erroronly="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-interleaved.rst
+++ b/doc/source/reference/parameters/omelasticsearch-interleaved.rst
@@ -1,0 +1,45 @@
+.. _param-omelasticsearch-interleaved:
+.. _omelasticsearch.parameter.module.interleaved:
+
+interleaved
+===========
+
+.. index::
+   single: omelasticsearch; interleaved
+   single: interleaved
+
+.. summary-start
+
+Store Elasticsearch bulk requests with their replies as paired entries in the error file.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: interleaved
+:Scope: action
+:Type: boolean
+:Default: action=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+When ``interleaved`` is enabled, :ref:`param-omelasticsearch-errorfile` captures
+each processed bulk operation as an object containing both the request payload
+and the Elasticsearch reply. With ``erroronly="off"`` every processed request is
+logged, providing a complete transcript for troubleshooting. When paired with
+:ref:`param-omelasticsearch-erroronly`, only the failed operations are recorded,
+but they retain the same request/response pairing.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-interleaved:
+.. _omelasticsearch.parameter.action.interleaved:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" interleaved="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.


### PR DESCRIPTION
## Summary
- add omelasticsearch erroronly and interleaved action parameters to the module overview
- document the behaviour of the erroronly and interleaved parameters in dedicated reference pages

## Testing
- ./doc/tools/build-doc-linux.sh --clean --strict --extra "-n"


------
https://chatgpt.com/codex/tasks/task_e_68cd820c2f94833286e3ef727c2a9ca6