### PR TITLE
omfile: add addLF option to append newline

### DIFF
--- a/doc/source/configuration/modules/omfile.rst
+++ b/doc/source/configuration/modules/omfile.rst
@@ -48,6 +48,7 @@ learn about different configuration languages in use by rsyslog.
 
 
    ../../reference/parameters/omfile-asyncwriting
+   ../../reference/parameters/omfile-addlf
    ../../reference/parameters/omfile-closetimeout
    ../../reference/parameters/omfile-compression-driver
    ../../reference/parameters/omfile-compression-zstd-workers
@@ -101,6 +102,10 @@ Module Parameters
      - Summary
    * - :ref:`param-omfile-template`
      - .. include:: ../../reference/parameters/omfile-template.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omfile-addlf`
+     - .. include:: ../../reference/parameters/omfile-addlf.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
    * - :ref:`param-omfile-dircreatemode`
@@ -172,6 +177,10 @@ selects whether a static or dynamic file (name) shall be written to.
      - Summary
    * - :ref:`param-omfile-template`
      - .. include:: ../../reference/parameters/omfile-template.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omfile-addlf`
+     - .. include:: ../../reference/parameters/omfile-addlf.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
    * - :ref:`param-omfile-fileowner`

--- a/doc/source/reference/parameters/omfile-addlf.rst
+++ b/doc/source/reference/parameters/omfile-addlf.rst
@@ -1,0 +1,59 @@
+.. _param-omfile-addlf:
+.. _omfile.parameter.module.addlf:
+
+addLF
+=====
+
+.. index::
+   single: omfile; addLF
+   single: addLF
+
+.. summary-start
+
+Ensures each written record ends with an LF by appending one when the message is missing it.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omfile`.
+
+:Name: addLF
+:Scope: module, action
+:Type: boolean
+:Default: module=off; action=inherits module
+:Required?: no
+:Introduced: 8.2410.0
+
+Description
+-----------
+
+When enabled, the omfile action checks whether a rendered message already
+terminates with an LF (line feed) before writing it. If not, omfile appends an
+LF so that every record ends with one, regardless of the template that produced
+the message. The additional byte is added transparently even when compression or
+cryptographic providers are enabled.
+
+When configured on the module, the setting becomes the default for all omfile
+actions that do not set ``addLF`` explicitly.
+
+Module usage
+------------
+
+.. _param-omfile-module-addlf:
+.. _omfile.parameter.module.addlf-usage:
+.. code-block:: rsyslog
+
+   module(load="builtin:omfile" addLF="on")
+
+Action usage
+------------
+
+.. _param-omfile-action-addlf:
+.. _omfile.parameter.action.addlf:
+.. code-block:: rsyslog
+
+   action(type="omfile" file="/var/log/messages" addLF="on")
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omfile`.

--- a/tests/omfile-addlf.sh
+++ b/tests/omfile-addlf.sh
@@ -1,0 +1,54 @@
+. ${srcdir:=.}/diag.sh init
+
+wait_for_nonempty_file() {
+    file="$1"
+    timeout=${2:-60}
+    waited=0
+    while [ $waited -lt $timeout ]; do
+        if [ -s "$file" ]; then
+            return 0
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    error_exit 1 "timeout waiting for $file to become non-empty"
+}
+
+generate_conf
+add_conf '
+module(load="builtin:omfile" addLF="on")
+template(name="rawfmt" type="string" string="%msg%")
+if $msg contains "use_module_default" then {
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'.module" template="rawfmt")
+    stop
+}
+if $msg contains "explicit_flag" then {
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'.explicit" template="rawfmt" addLF="on")
+    stop
+}
+if $msg contains "force_off" then {
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'.override" template="rawfmt" addLF="off")
+    stop
+}
+'
+
+startup
+injectmsg_literal '<165>1 2024-01-01T00:00:00.000000Z host app - - - use_module_default'
+injectmsg_literal '<165>1 2024-01-01T00:00:01.000000Z host app - - - explicit_flag'
+injectmsg_literal '<165>1 2024-01-01T00:00:02.000000Z host app - - - force_off'
+shutdown_when_empty
+wait_shutdown
+
+wait_file_lines "$RSYSLOG_OUT_LOG.module" 1
+wait_file_lines "$RSYSLOG_OUT_LOG.explicit" 1
+wait_for_nonempty_file "$RSYSLOG_OUT_LOG.override"
+
+printf 'use_module_default\n' > "$RSYSLOG_OUT_LOG.module.expected"
+printf 'explicit_flag\n' > "$RSYSLOG_OUT_LOG.explicit.expected"
+printf 'force_off' > "$RSYSLOG_OUT_LOG.override.expected"
+
+cmp "$RSYSLOG_OUT_LOG.module.expected" "$RSYSLOG_OUT_LOG.module" || error_exit 1 "module default addLF mismatch"
+cmp "$RSYSLOG_OUT_LOG.explicit.expected" "$RSYSLOG_OUT_LOG.explicit" || error_exit 1 "explicit addLF mismatch"
+cmp "$RSYSLOG_OUT_LOG.override.expected" "$RSYSLOG_OUT_LOG.override" || error_exit 1 "addLF override failed"
+
+exit_test

--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -143,6 +143,7 @@ typedef struct s_dynaFileCacheEntry dynaFileCacheEntry;
 #define FLUSH_INTRVL_DFLT 1 /**< default buffer flush interval (in seconds) */
 #define USE_ASYNCWRITER_DFLT 0 /**< default buffer use async writer */
 #define FLUSHONTX_DFLT 1 /**< default for flush on TX end */
+#define ADDLF_SIGBUF_STACKLEN 1024 /**< stack buffer size for addLF signing helper */
 
 /**
  * @brief Instance data for the omfile module.
@@ -197,6 +198,7 @@ typedef struct _instanceData {
     sbool bFlushOnTXEnd; /**< flush write buffers when transaction has ended? */
     sbool bUseAsyncWriter; /**< use async stream writer? */
     sbool bVeryRobustZip;
+    sbool bAddLF; /**< append LF to records that are missing it? */
     statsobj_t *stats; /**< dynafile, primarily cache stats */
     STATSCOUNTER_DEF(ctrRequests, mutCtrRequests);
     STATSCOUNTER_DEF(ctrLevel0, mutCtrLevel0);
@@ -239,6 +241,7 @@ typedef struct configSettings_s {
     int64 iIOBufSize; /**< size of an io buffer */
     int iFlushInterval; /**< how often flush the output buffer on inactivity? */
     int bUseAsyncWriter; /**< should we enable asynchronous writing? */
+    sbool bAddLF; /**< append LF to records that are missing it? */
     EMPTY_STRUCT
 } configSettings_t;
 static configSettings_t cs;
@@ -259,6 +262,7 @@ struct modConfData_s {
     int bDynafileDoNotSuspend;
     strm_compressionDriver_t compressionDriver;
     int compressionDriver_workers;
+    sbool addLF; /**< default setting for addLF action parameter */
 };
 
 static modConfData_t *loadModConf = NULL; /**< modConf ptr to use for the current load process */
@@ -268,6 +272,7 @@ static modConfData_t *runModConf = NULL; /**< modConf ptr to use for the current
 /* module-global parameters */
 static struct cnfparamdescr modpdescr[] = {
     {"template", eCmdHdlrGetWord, 0},
+    {"addlf", eCmdHdlrBinary, 0},
     {"compression.driver", eCmdHdlrGetWord, 0},
     {"compression.zstd.workers", eCmdHdlrPositiveInt, 0},
     {"dircreatemode", eCmdHdlrFileCreateMode, 0},
@@ -312,7 +317,8 @@ static struct cnfparamdescr actpdescr[] = {{"dynafilecachesize", eCmdHdlrInt, 0}
                                            {"closetimeout", eCmdHdlrPositiveInt, 0},
                                            {"rotation.sizelimit", eCmdHdlrSize, 0},
                                            {"rotation.sizelimitcommand", eCmdHdlrString, 0},
-                                           {"template", eCmdHdlrGetWord, 0}};
+                                           {"template", eCmdHdlrGetWord, 0},
+                                           {"addlf", eCmdHdlrBinary, 0}};
 static struct cnfparamblk actpblk = {CNFPARAMBLK_VERSION, sizeof(actpdescr) / sizeof(struct cnfparamdescr), actpdescr};
 
 
@@ -358,6 +364,7 @@ BEGINdbgPrintInstInfo
     dbgprintf("\tuse async writer=%d\n", pData->bUseAsyncWriter);
     dbgprintf("\tflush on TX end=%d\n", pData->bFlushOnTXEnd);
     dbgprintf("\tflush interval=%d\n", pData->iFlushInterval);
+    dbgprintf("\tappend LF=%d\n", pData->bAddLF);
     dbgprintf("\tfile cache size=%d\n", pData->iDynaFileCacheSize);
     dbgprintf("\tcreate directories: %s\n", pData->bCreateDirs ? "on" : "off");
     dbgprintf("\tvery robust zip: %s\n", pData->bCreateDirs ? "on" : "off");
@@ -878,15 +885,50 @@ static rsRetVal doWrite(instanceData *__restrict__ const pData, uchar *__restric
     assert(pData != NULL);
     assert(pszBuf != NULL);
 
-    DBGPRINTF("omfile: write to stream, pData->pStrm %p, lenBuf %d, strt data %.128s\n", pData->pStrm, lenBuf, pszBuf);
+    const int needsLF = pData->bAddLF && (lenBuf == 0 || pszBuf[lenBuf - 1] != '\n');
+    uchar addlfBuf[ADDLF_SIGBUF_STACKLEN];
+    uchar *sigBuf = NULL;
+    size_t sigLen = 0;
+    int freeSigBuf = 0;
+
+    DBGPRINTF("omfile: write to stream, pData->pStrm %p, lenBuf %d, needsLF %d, strt data %.128s\n", pData->pStrm,
+              lenBuf, needsLF, pszBuf);
     if (pData->pStrm != NULL) {
-        CHKiRet(strm.Write(pData->pStrm, pszBuf, lenBuf));
+        if (lenBuf > 0) {
+            CHKiRet(strm.Write(pData->pStrm, pszBuf, lenBuf));
+        }
+        if (needsLF) {
+            if (pData->useSigprov) {
+                sigLen = (size_t)lenBuf + 1;
+                if (sigLen <= sizeof(addlfBuf)) {
+                    sigBuf = addlfBuf;
+                } else {
+                    sigBuf = (uchar *)malloc(sigLen);
+                    if (sigBuf == NULL) {
+                        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+                    }
+                    freeSigBuf = 1;
+                }
+                if (lenBuf > 0) {
+                    memcpy(sigBuf, pszBuf, (size_t)lenBuf);
+                }
+                sigBuf[lenBuf] = '\n';
+            }
+            CHKiRet(strm.WriteChar(pData->pStrm, '\n'));
+        }
         if (pData->useSigprov) {
-            CHKiRet(pData->sigprov.OnRecordWrite(pData->sigprovFileData, pszBuf, lenBuf));
+            if (needsLF) {
+                CHKiRet(pData->sigprov.OnRecordWrite(pData->sigprovFileData, sigBuf, (rs_size_t)sigLen));
+            } else {
+                CHKiRet(pData->sigprov.OnRecordWrite(pData->sigprovFileData, pszBuf, lenBuf));
+            }
         }
     }
 
 finalize_it:
+    if (freeSigBuf) {
+        free(sigBuf);
+    }
     RETiRet;
 }
 
@@ -946,6 +988,7 @@ BEGINbeginCnfLoad
     pModConf->fileGID = -1;
     pModConf->dirGID = -1;
     pModConf->bDynafileDoNotSuspend = 1;
+    pModConf->addLF = 0;
 ENDbeginCnfLoad
 
 BEGINsetModCnf
@@ -978,6 +1021,8 @@ BEGINsetModCnf
                     "set via legacy directive - may lead to inconsistent "
                     "results.");
             }
+        } else if (!strcmp(modpblk.descr[i].name, "addlf")) {
+            loadModConf->addLF = pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "compression.driver")) {
             if (!es_strcasebufcmp(pvals[i].val.d.estr, (const unsigned char *)"zlib", 4)) {
                 loadModConf->compressionDriver = STRM_COMPRESS_ZIP;
@@ -1107,6 +1152,7 @@ ENDfreeCnf
 BEGINcreateInstance
     CODESTARTcreateInstance;
     pData->pStrm = NULL;
+    pData->bAddLF = 0;
     pthread_mutex_init(&pData->mutWrite, NULL);
 ENDcreateInstance
 
@@ -1221,6 +1267,7 @@ static void setInstParamDefaults(instanceData *__restrict__ const pData) {
     pData->iIOBufSize = IOBUF_DFLT_SIZE;
     pData->iFlushInterval = FLUSH_INTRVL_DFLT;
     pData->bUseAsyncWriter = USE_ASYNCWRITER_DFLT;
+    pData->bAddLF = loadModConf->addLF;
     pData->sigprovName = NULL;
     pData->cryprovName = NULL;
     pData->useSigprov = 0;
@@ -1448,6 +1495,8 @@ BEGINnewActInst
             pData->bSyncFile = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "createdirs")) {
             pData->bCreateDirs = (int)pvals[i].val.d.n;
+        } else if (!strcmp(actpblk.descr[i].name, "addlf")) {
+            pData->bAddLF = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "file")) {
             pData->fname = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
             CODE_STD_STRING_REQUESTnewActInst(1);
@@ -1627,6 +1676,7 @@ BEGINparseSelectorAct
     pData->iIOBufSize = (int)cs.iIOBufSize;
     pData->iFlushInterval = cs.iFlushInterval;
     pData->bUseAsyncWriter = cs.bUseAsyncWriter;
+    pData->bAddLF = cs.bAddLF;
     pData->bVeryRobustZip = 0; /* cannot be specified via legacy conf */
     pData->iCloseTimeout = 0; /* cannot be specified via legacy conf */
     setupInstStatsCtrs(pData);
@@ -1660,6 +1710,7 @@ static rsRetVal resetConfigVariables(uchar __attribute__((unused)) * pp, void __
     cs.iIOBufSize = IOBUF_DFLT_SIZE;
     cs.iFlushInterval = FLUSH_INTRVL_DFLT;
     cs.bUseAsyncWriter = USE_ASYNCWRITER_DFLT;
+    cs.bAddLF = 0;
     free(pszFileDfltTplName);
     pszFileDfltTplName = NULL;
     return RS_RET_OK;
@@ -1719,6 +1770,7 @@ BEGINmodInit(File)
                                STD_LOADABLE_MODULE_ID));
     CHKiRet(omsdRegCFSLineHdlr((uchar *)"omfileflushontxend", 0, eCmdHdlrBinary, NULL, &cs.bFlushOnTXEnd,
                                STD_LOADABLE_MODULE_ID));
+    CHKiRet(omsdRegCFSLineHdlr((uchar *)"omfileaddlf", 0, eCmdHdlrBinary, NULL, &cs.bAddLF, STD_LOADABLE_MODULE_ID));
     CHKiRet(omsdRegCFSLineHdlr((uchar *)"omfileiobuffersize", 0, eCmdHdlrSize, NULL, &cs.iIOBufSize,
                                STD_LOADABLE_MODULE_ID));
     CHKiRet(omsdRegCFSLineHdlr((uchar *)"dirowner", 0, eCmdHdlrUID, NULL, &cs.dirUID, STD_LOADABLE_MODULE_ID));


### PR DESCRIPTION
## Summary
- add an addLF module/action parameter for omfile that defaults to off and propagates to legacy configuration
- append a trailing newline in doWrite when requested, covering signature providers and other modes
- document the new option and add a regression test that checks module defaults and per-action overrides

## Testing
- tests/omfile-addlf.sh

------
https://chatgpt.com/codex/tasks/task_e_68ce63a39a788332884aca8d31c35df8