### PR TITLE
jsonf: add omitIfZero option for numeric fields

### DIFF
--- a/doc/source/reference/templates/templates-statement-property.rst
+++ b/doc/source/reference/templates/templates-statement-property.rst
@@ -88,4 +88,6 @@ Parameters
 
 - ``onEmpty`` – for ``jsonf`` format only; handling of empty values:
   ``keep``, ``skip``, or ``null``
+- ``omitIfZero`` – for ``jsonf`` format with ``dataType="number"``; omit the
+  field when the rendered numeric value is zero
 

--- a/doc/source/reference/templates/templates-statement-property.rst
+++ b/doc/source/reference/templates/templates-statement-property.rst
@@ -88,6 +88,6 @@ Parameters
 
 - ``onEmpty`` – for ``jsonf`` format only; handling of empty values:
   ``keep``, ``skip``, or ``null``
-- ``omitIfZero`` – for ``jsonf`` format with ``dataType="number"``; omit the
-  field when the rendered numeric value is zero
+- ``omitIfZero`` – for ``jsonf`` or ``jsonfr`` format with ``dataType="number"``;
+  omit the field when the rendered numeric value is zero
 

--- a/template.h
+++ b/template.h
@@ -155,6 +155,7 @@ struct templateEntry {
                 unsigned bJSONr : 1; /* format field JSON non escaped */
                 unsigned bJSONfr : 1; /* format field JSON *field* non escaped (n/v pair) */
                 unsigned bMandatory : 1; /* mandatory field - emit even if empty */
+                unsigned bOmitIfZero : 1; /* drop numeric field when value is zero */
                 unsigned bFromPosEndRelative : 1; /* is From/To-Pos relative to end of string? */
                 unsigned bFixedWidth : 1; /* space pad to toChar if string is shorter */
                 unsigned bDateInUTC : 1; /* should date be expressed in UTC? */

--- a/tests/json-omitifzero.sh
+++ b/tests/json-omitifzero.sh
@@ -9,6 +9,8 @@ template(name="json" type="list" option.jsonf="on") {
         property(outname="status_zero" format="jsonf" name="$!status" datatype="number" omitIfZero="on")
         property(outname="status_nonzero" format="jsonf" name="$!other" datatype="number" omitIfZero="on")
         property(outname="status_empty" format="jsonf" name="$!empty" datatype="number" omitIfZero="on" onEmpty="null")
+        property(outname="status_zero_fr" format="jsonfr" name="$!status" datatype="number" omitIfZero="on")
+        property(outname="status_nonzero_fr" format="jsonfr" name="$!other" datatype="number" omitIfZero="on")
 }
 
 set $!status = "0";
@@ -20,6 +22,7 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="json")
 startup
 shutdown_when_empty
 wait_shutdown
-content_check '{"status_nonzero":200, "status_empty":null}'
+content_check '{"status_nonzero":200, "status_empty":null, "status_nonzero_fr":200}'
 check_not_present 'status_zero'
+check_not_present 'status_zero_fr'
 exit_test

--- a/tests/json-omitifzero.sh
+++ b/tests/json-omitifzero.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+# written 2025-09-26 by AI Assistant
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+template(name="json" type="list" option.jsonf="on") {
+        property(outname="status_zero" format="jsonf" name="$!status" datatype="number" omitIfZero="on")
+        property(outname="status_nonzero" format="jsonf" name="$!other" datatype="number" omitIfZero="on")
+        property(outname="status_empty" format="jsonf" name="$!empty" datatype="number" omitIfZero="on" onEmpty="null")
+}
+
+set $!status = "0";
+set $!other = "200";
+set $!empty = "";
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="json")
+'
+
+startup
+shutdown_when_empty
+wait_shutdown
+content_check '{"status_nonzero":200, "status_empty":null}'
+check_not_present 'status_zero'
+exit_test


### PR DESCRIPTION
## Summary
- add support for an omitIfZero option on jsonf property statements when datatype="number"
- teach jsonField() to drop zero-valued numbers and document the new setting
- cover the behaviour with a regression test

## Testing
- tests/json-omitifzero.sh

------
https://chatgpt.com/codex/tasks/task_e_68d4f5c649d48332a91e42f337389ec3