### PR TITLE
docs: add omelasticsearch module agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,21 @@ This file defines guidelines and instructions for AI assistants (e.g., Codex, Gi
       - [`liblognorm`](https://github.com/rsyslog/liblognorm)
       - [`librelp`](https://github.com/rsyslog/librelp)
       - [`libestr`](https://github.com/rsyslog/libestr)
-      - [`libfastjson`](https://github.com/rsyslog/libfastjson): A fork of libfastjson by the rsyslog project, optimized for speed. This library is used by multiple external projects.
+  - [`libfastjson`](https://github.com/rsyslog/libfastjson): A fork of libfastjson by the rsyslog project, optimized for speed. This library is used by multiple external projects.
+
+-----
+
+## Quick links for agents
+
+  - **Documentation subtree guide:** [`doc/AGENTS.md`](./doc/AGENTS.md)
+  - **Core plugin subtree guide:** [`plugins/AGENTS.md`](./plugins/AGENTS.md)
+  - **Contrib module subtree guide:** [`contrib/AGENTS.md`](./contrib/AGENTS.md)
+  - **Module author checklist:** [`MODULE_AUTHOR_CHECKLIST.md`](./MODULE_AUTHOR_CHECKLIST.md)
+  - **Developer overview:** [`DEVELOPING.md`](./DEVELOPING.md)
+  - **Commit prompt template:** [`ai/rsyslog_commit_assistant/base_prompt.txt`](./ai/rsyslog_commit_assistant/base_prompt.txt)
+
+Use these jump points together with this file to locate the workflow and
+component notes that apply to your task.
 
 -----
 
@@ -114,6 +128,28 @@ will automatically apply these rules.
 
 Whenever `.c` or `.h` files are modified, a build should be performed using `make`.
 If new functionality is introduced, at least a basic test should be created and run.
+
+### Generating the autotools build system
+
+The `configure` script and `Makefile.in` files are **not** stored in git. After a
+fresh checkout—or any time `configure.ac`, `Makefile.am`, or macros under `m4/`
+change—you **must** run:
+
+```bash
+./autogen.sh
+```
+
+This bootstraps autotools, downloads any required macros, and generates
+`configure`. Skipping this step is the most common reason for messages such as
+`configure: error: cannot find install-sh, install.sh, or shtool` or `make:
+*** No targets specified and no makefile found`. If a cleanup removed the
+generated files (e.g., `git clean -xfd`), re-run `./autogen.sh` before
+configuring again.
+
+If `autogen.sh` fails, run `./devtools/codex-setup.sh` first to install the
+toolchain dependencies inside the sandbox, then retry `./autogen.sh`.
+
+### Configure & build
 
 If possible, agents should:
 

--- a/contrib/AGENTS.md
+++ b/contrib/AGENTS.md
@@ -1,0 +1,59 @@
+# AGENTS.md – Contrib modules subtree
+
+These instructions apply to everything under `contrib/`.
+
+## Expectations for contrib work
+- Contrib modules are not part of the core support contract.  Changes should
+  preserve backward compatibility for existing users and clearly call out
+  behaviour shifts in commit messages and documentation.
+- Many contrib modules depend on third-party SDKs or services that are not
+  available in CI.  Document any manual setup that reviewers must perform.
+
+## Build & bootstrap reminders
+- Run `./autogen.sh` before your first build in a fresh checkout and whenever
+  you modify autotools inputs (`configure.ac`, `Makefile.am`, `m4/`).  Expect
+  the bootstrap step to take up to about 2 minutes; you can skip it when the
+  task does not require building (for example, documentation-only changes).
+- Configure with the switches needed to include the contrib module.  Some
+  modules are disabled unless their dependencies are detected.  Use
+  `./configure --help` and the module's `MODULE_METADATA.yaml` to identify
+  the relevant `--enable`/`--with` flags.
+- Build with `make -j$(nproc)` and run `make check`.  If the full test suite is
+  impractical (for example because the module talks to external services), run
+  and document the narrowest reproducible subset of tests.
+
+## Metadata required for every module
+Each contrib module directory (for example `contrib/mmkubernetes/`) must contain
+`MODULE_METADATA.yaml`.  Contrib metadata uses the same schema as core plugins,
+with different default expectations.
+
+### Required keys
+```yaml
+support_status: contributor-supported | stalled
+maturity_level: fully-mature | mature | fresh | experimental
+primary_contact: "Full Name <email@example.com>" | "(unassigned)"
+last_reviewed: YYYY-MM-DD
+```
+
+- Default `support_status` is `contributor-supported` unless the core team has
+  formally adopted the module.
+- Use `stalled` if no maintainer is known.  Do not set `core-supported` unless
+  the module has moved to `plugins/`.
+
+### Optional keys
+Reuse the optional keys from `plugins/MODULE_METADATA_TEMPLATE.yaml` to document
+build/runtime requirements, CI coverage, and reviewer notes.  Copy
+`contrib/MODULE_METADATA_TEMPLATE.yaml` when creating the file.
+
+## Testing expectations
+- Prefer smoke tests that can run under `make check` without proprietary
+  services.  If that is impossible, provide script stubs in `tests/` that mock
+  or skip the integration but keep API coverage verifiable.
+- Record any external test environments (container images, cloud resources) in
+  the module metadata so reviewers understand the manual steps required.
+
+## Documentation touchpoints
+- Update `doc/` to mention new or changed contrib modules, especially when the
+  module has prerequisites or manual installation steps.
+- When a contrib module becomes core-supported, move it under `plugins/`, update
+  the metadata accordingly, and inform maintainers via the changelog.

--- a/contrib/MODULE_METADATA_TEMPLATE.yaml
+++ b/contrib/MODULE_METADATA_TEMPLATE.yaml
@@ -1,0 +1,11 @@
+# Copy this file into a contrib module directory and adjust values.
+support_status: contributor-supported  # contributor-supported | stalled
+maturity_level: fresh                  # fully-mature | mature | fresh | experimental
+primary_contact: "(unassigned)"
+last_reviewed: 2024-01-01
+build_dependencies: []
+runtime_dependencies: []
+ci_targets: []
+documentation: []
+notes: |-
+  Document manual setup steps and any missing CI coverage here.

--- a/doc/AGENTS.md
+++ b/doc/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md – Documentation subtree
+
+This guide applies to everything under `doc/`.
+
+## Purpose & scope
+- The `doc/` tree contains the Sphinx documentation sources plus helper tools.
+- Use this file together with the top-level `AGENTS.md` instructions.
+
+## Editing guidelines
+- Prefer reStructuredText (`*.rst`) for content; Markdown files exist for historical reasons.
+- Keep headings consistent with the existing `doc/README.md` conventions.
+- Cross-link new material from `doc/README.md` or the relevant `index.rst` so it is discoverable.
+- When touching shared style guidance, update `doc/STRATEGY.md` if needed.
+
+## Build & validation
+- After content changes, run `./doc/tools/build-doc-linux.sh --clean --format html` locally when possible to catch Sphinx errors.
+- For quick linting without rebuilding everything, run `make -C doc html` (uses the repo's virtualenv if already set up).
+- Document-only changes generally do not require running the full C test suite.
+
+## Commit messaging
+- Summarize the reader impact (new topics, reorganized structure, typo fixes) in the commit body.
+- Include the `AI-Agent: ChatGPT` trailer as requested by the repository guidelines.
+
+## Coordination
+- If a change affects module-specific docs, check `doc/ai/module_map.yaml` for component details and mention any locking or
+  runtime considerations in the documentation where relevant.

--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -1,4 +1,7 @@
 # Seed map for AI agents; keep minimal and truthful. Extend over time.
+# Per-module metadata (support status, maturity, contacts) lives in each module
+# directory as `MODULE_METADATA.yaml`; update both the metadata file and this map
+# when concurrency guidance changes.
 omfile:
   paths: ["plugins/omfile/"]
   requires_serialization: true

--- a/plugins/AGENTS.md
+++ b/plugins/AGENTS.md
@@ -1,0 +1,98 @@
+# AGENTS.md – Core plugins subtree
+
+These instructions apply to everything under `plugins/` (except `plugins/external`,
+which vendors third-party code; do not modify it unless specifically requested).
+
+## Build & bootstrap reminders
+- Run `./autogen.sh` before your **first** build in a fresh checkout and
+  whenever you touch `configure.ac`, any `Makefile.am`, or files under `m4/`.
+  The bootstrap step can take up to ~2 minutes, so skip it for pure
+  documentation or metadata-only edits when no build is required.
+- Configure with the options needed for the module you are touching.  The
+  defaults build all modules whose dependencies are present.  Use
+  `./configure --help` to discover `--enable`/`--disable` switches if you need
+  to constrain the build.
+- Keep the testbench enabled with `./configure --enable-testbench` so
+  module-specific tests continue to compile.
+- Build with `make -j$(nproc)` and run at least `make check` before submitting
+  changes.  To focus on one module, run `make <testname>.log` as described in
+  `tests/README`.
+
+## Module-level agent guides
+High-complexity modules benefit from their own `AGENTS.md` living directly
+inside the module directory (for example `plugins/omelasticsearch/AGENTS.md`).
+Use them to capture:
+
+- A short overview plus links to user-facing docs.
+- Build or dependency switches that only affect this module.
+- Smoke/regression tests to run locally and any helper scripts to prepare
+  external services.
+- Common troubleshooting tips (log messages, stats counters, error files).
+- Coordination notes when touching shared helpers or cross-module contracts.
+- References to `MODULE_METADATA.yaml` and other metadata that must stay in
+  sync.
+
+Copy `plugins/MODULE_AGENTS_TEMPLATE.md` when creating a new module guide and
+update it whenever workflows or dependencies change.
+
+## Metadata required for every module
+Each module directory (for example `plugins/omfile/`) must contain a
+`MODULE_METADATA.yaml` file.  The file communicates ownership and expectations
+for both humans and agents.
+
+### Required keys
+```yaml
+support_status: core-supported | contributor-supported | stalled
+maturity_level: fully-mature | mature | fresh | experimental
+primary_contact: "Full Name <email@example.com>" | "(unassigned)"
+last_reviewed: YYYY-MM-DD
+```
+
+#### Support status values
+- `core-supported`: Maintained by the rsyslog core team.
+- `contributor-supported`: Maintained primarily by a community contributor; the
+  core team reviews but does not lead feature work.
+- `stalled`: No active maintainer; use extra caution before changing behaviour.
+
+#### Maturity level values
+- `fully-mature`: Long-standing module with well-established interfaces.
+- `mature`: Stable but with medium deployment footprint or recent major changes.
+- `fresh`: Recently added or lightly used; expect feedback-driven revisions.
+- `experimental`: Works, but explicitly needs broader testing feedback before it
+  can be considered stable.
+
+### Optional keys
+Add keys as needed to help future contributors:
+- `build_dependencies`: List library or tool requirements (match configure
+  options when possible).
+- `runtime_dependencies`: Libraries or services the module needs at runtime.
+- `ci_targets`: Names of CI jobs or scripts that exercise this module.
+- `documentation`: Links into `doc/` or external references.
+- `notes`: Free-form guidance for reviewers and contributors.
+
+### Template
+Copy `plugins/MODULE_METADATA_TEMPLATE.yaml` when creating or updating
+module metadata.  Keep values accurate and review them whenever ownership or
+support expectations change.
+
+## Coding expectations
+- Follow `MODULE_AUTHOR_CHECKLIST.md` for concurrency and documentation tasks.
+- Update the module's top-of-file "Concurrency & Locking" comment when
+  behaviour changes.
+- Update `doc/ai/module_map.yaml` if concurrency expectations change.
+- When adding a new module, update `plugins/Makefile.am`, `configure.ac`, and
+  provide tests under `tests/` to cover the new behaviour.
+
+## Testing expectations
+- Prefer module-focused tests in `tests/` named after the module (e.g.
+  `omxyz-basic.sh`).
+- Ensure new tests run cleanly under `make check`.
+- When a module requires external services (databases, message queues, etc.),
+  document setup steps in the module metadata and reference any helper scripts
+  placed under `tests/`.
+
+## Documentation touchpoints
+- Mention significant behaviour or dependency changes in `doc/` (for example,
+  module reference guides or changelog entries).
+- Cross-link any new documentation from the appropriate `index.rst` so users
+  can discover it easily.

--- a/plugins/MODULE_AGENTS_TEMPLATE.md
+++ b/plugins/MODULE_AGENTS_TEMPLATE.md
@@ -1,0 +1,29 @@
+# AGENTS.md – <module name>
+
+## Module overview
+- Purpose of the module and key user documentation links.
+- Support status & maturity (mirror `MODULE_METADATA.yaml`).
+
+## Build & dependencies
+- Configure flags to enable the module (e.g. `--enable-foo`).
+- Library/tool prerequisites and how to install them inside the sandbox.
+- Reminders about rerunning `./autogen.sh` or `configure` when touching build
+  inputs.
+
+## Local testing
+- Smoke tests (`make foo-basic.log`) and longer scenarios.
+- Helpers or environment variables required to provision external services.
+- Notes about test runtime or resource requirements.
+
+## Diagnostics & troubleshooting
+- Key log messages, stats counters, or generated files that validate success.
+- Typical failure signatures and quick triage steps.
+
+## Cross-component coordination
+- Shared helpers or configuration formats that must stay aligned.
+- Other modules or docs to update when behaviour changes.
+
+## Metadata & housekeeping
+- Remind contributors to update `MODULE_METADATA.yaml`.
+- Call out any templates or automation that need refreshing alongside code
+  changes.

--- a/plugins/MODULE_METADATA_TEMPLATE.yaml
+++ b/plugins/MODULE_METADATA_TEMPLATE.yaml
@@ -1,0 +1,15 @@
+# Copy this file into a module directory (e.g. plugins/omfile/) and adjust values.
+# Keep the keys ordered as shown so diffs stay readable.
+support_status: core-supported        # core-supported | contributor-supported | stalled
+maturity_level: mature                # fully-mature | mature | fresh | experimental
+primary_contact: "(unassigned)"       # Use "Full Name <email>" when known.
+last_reviewed: 2024-01-01             # Update whenever metadata changes.
+build_dependencies: []                # Optional: list pkg-config names or tools.
+runtime_dependencies: []              # Optional: list services or daemons.
+ci_targets: []                        # Optional: list CI jobs or scripts.
+documentation: []                     # Optional: list doc/*.rst paths or URLs.
+notes: |-
+  Replace this block with free-form context such as:
+  - Known limitations
+  - Links to design documents
+  - How to run module-focused smoke tests

--- a/plugins/omelasticsearch/AGENTS.md
+++ b/plugins/omelasticsearch/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md – omelasticsearch output module
+
+## Module overview
+- Ships events to Elasticsearch via HTTP bulk requests using libcurl.
+- User documentation: `doc/source/configuration/modules/omelasticsearch.rst`.
+- Support status: core-supported. Maturity: fully-mature.
+
+## Build & dependencies
+- Configure with `--enable-elasticsearch` to compile this plugin.
+- `./devtools/codex-setup.sh` installs the required libcurl development headers
+  inside the sandbox.
+- Re-run `./configure` after toggling the flag; rerun `./autogen.sh` if you touch
+  `configure.ac`, any `Makefile.am`, or macros under `m4/`.
+
+## Local testing
+- Enable module-specific tests with `--enable-elasticsearch-tests=minimal` (or
+  `yes`) during `./configure`.
+- Smoke test: `make es-basic.log`. Additional coverage: `make
+  es-basic-ha.log`, `make es-bulk-errfile-popul.log`, and
+  `make es-bulk-retry.log`.
+- Tests require a local Elasticsearch instance. Use the helpers in
+  `tests/diag.sh`, e.g.:
+  ```bash
+  (. ./tests/diag.sh; ensure_elasticsearch_ready; init_elasticsearch)
+  ```
+  `ES_DOWNLOAD` can be set before sourcing to pin a different release.
+
+## Diagnostics & troubleshooting
+- impstats exposes the `omelasticsearch` counter set (submitted, fail.http,
+  fail.httprequests, fail.es, and the retry-focused `response.*` metrics when
+  `retryfailures="on"`).
+- Configure `errorfile="/path/to/errors.json"` while testing to capture raw
+  Elasticsearch responses for triage.
+- Watch for `writeoperation` validation failures; tests like
+  `es-writeoperation.sh` enforce accepted values.
+
+## Cross-component coordination
+- Template changes that alter JSON structure must be mirrored in
+  `doc/source/configuration/modules/omelasticsearch.rst` and in the
+  parameter reference snippets under `doc/source/reference/parameters/`.
+- Updates that touch the curl helper patterns should be reviewed alongside
+  other HTTP-based plugins (e.g., `contrib/omhttp`).
+
+## Metadata & housekeeping
+- Keep `plugins/omelasticsearch/MODULE_METADATA.yaml` current when ownership or
+  maturity changes.
+- Update `doc/ai/module_map.yaml` and relevant tests if new configuration
+  options or diagnostics are introduced.

--- a/plugins/omelasticsearch/MODULE_METADATA.yaml
+++ b/plugins/omelasticsearch/MODULE_METADATA.yaml
@@ -1,0 +1,16 @@
+support_status: core-supported
+maturity_level: fully-mature
+primary_contact: "(unassigned)"
+last_reviewed: 2024-06-22
+build_dependencies:
+  - libcurl development headers (`./devtools/codex-setup.sh`)
+runtime_dependencies:
+  - Elasticsearch 7.x or later reachable over HTTP(S)
+ci_targets:
+  - es-basic.sh
+  - es-bulk-errfile-popul.sh
+  - es-bulk-retry.sh
+documentation:
+  - doc/source/configuration/modules/omelasticsearch.rst
+notes:
+  - Testbench downloads Elasticsearch via `tests/diag.sh`; set ES_DOWNLOAD to pin versions.


### PR DESCRIPTION
## Summary
- encourage module-level AGENTS files in the plugins guide and link to a reusable template
- add a module agent guide for omelasticsearch covering build, test, and diagnostics workflows
- record omelasticsearch ownership metadata to surface support status and dependencies

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d6336a7eb4833290c233d4e2714e00