### PR TITLE
Improve imtcp peer logging to include source ports

### DIFF
--- a/runtime/prop.h
+++ b/runtime/prop.h
@@ -66,6 +66,14 @@ static inline uchar *__attribute__((unused)) ATTR_NONNULL(1) propGetSzStr(prop_t
     return (pThis->len < CONF_PROP_BUFSIZE) ? pThis->szVal.sz : pThis->szVal.psz;
 }
 
+static inline const char *__attribute__((unused)) propGetSzStrOrDefault(prop_t *pThis, const char *dflt) {
+    return (pThis != NULL) ? (const char *)propGetSzStr(pThis) : dflt;
+}
+
+static inline const char *__attribute__((unused)) szStrOrDefault(const uchar *psz, const char *dflt) {
+    return (psz != NULL) ? (const char *)psz : dflt;
+}
+
 /* prototypes */
 PROTOTYPEObj(prop);
 

--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -201,12 +201,9 @@ static ATTR_NONNULL() rsRetVal maybeDetectTlsClientHello(tcps_sess_t *pThis, con
 
     if (pThis->tlsProbeBytes >= sizeof(pThis->tlsProbeBuf)) {
         if (!pThis->tlsMismatchWarned && isLikelyTlsClientHello(pThis->tlsProbeBuf)) {
-            const char *const host =
-                (pThis->fromHost != NULL) ? (const char *)propGetSzStr(pThis->fromHost) : "(host unknown)";
-            const char *const ip =
-                (pThis->fromHostIP != NULL) ? (const char *)propGetSzStr(pThis->fromHostIP) : "(IP unknown)";
-            const char *const port =
-                (pThis->fromHostPort != NULL) ? (const char *)propGetSzStr(pThis->fromHostPort) : "(port unknown)";
+            const char *const host = propGetSzStrOrDefault(pThis->fromHost, "(host unknown)");
+            const char *const ip = propGetSzStrOrDefault(pThis->fromHostIP, "(IP unknown)");
+            const char *const port = propGetSzStrOrDefault(pThis->fromHostPort, "(port unknown)");
             LogError(0, RS_RET_SERVER_NO_TLS,
                      "imtcp: TLS handshake detected from %s (%s:%s) but listener is not TLS-enabled. "
                      "Enable TLS on this listener or disable TLS on the client. "
@@ -496,12 +493,9 @@ static rsRetVal ATTR_NONNULL(1) processDataRcvd(tcps_sess_t *pThis,
             }
         } else { /* done with the octet count, so this must be the SP terminator */
             DBGPRINTF("TCP Message with octet-counter, size %d.\n", pThis->iOctetsRemain);
-            const char *const peerName =
-                (pThis->fromHost != NULL) ? (const char *)propGetSzStr(pThis->fromHost) : "(hostname unknown)";
-            const char *const peerIP =
-                (pThis->fromHostIP != NULL) ? (const char *)propGetSzStr(pThis->fromHostIP) : "(IP unknown)";
-            const char *const peerPort =
-                (pThis->fromHostPort != NULL) ? (const char *)propGetSzStr(pThis->fromHostPort) : "(port unknown)";
+            const char *const peerName = propGetSzStrOrDefault(pThis->fromHost, "(hostname unknown)");
+            const char *const peerIP = propGetSzStrOrDefault(pThis->fromHostIP, "(IP unknown)");
+            const char *const peerPort = propGetSzStrOrDefault(pThis->fromHostPort, "(port unknown)");
             if (c != ' ') {
                 LogError(0, NO_ERRCODE,
                          "imtcp %s: Framing Error in received TCP message from "

--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -495,26 +495,26 @@ static rsRetVal ATTR_NONNULL(1) processDataRcvd(tcps_sess_t *pThis,
                 *(pThis->pMsg + pThis->iMsg++) = c;
             }
         } else { /* done with the octet count, so this must be the SP terminator */
-            uchar *propPeerName = NULL;
-            uchar *propPeerIP = NULL;
-            int lenPeerName = 0;
-            int lenPeerIP = 0;
             DBGPRINTF("TCP Message with octet-counter, size %d.\n", pThis->iOctetsRemain);
-            prop.GetString(pThis->fromHost, &propPeerName, &lenPeerName);
-            prop.GetString(pThis->fromHost, &propPeerIP, &lenPeerIP);
+            const char *const peerName =
+                (pThis->fromHost != NULL) ? (const char *)propGetSzStr(pThis->fromHost) : "(hostname unknown)";
+            const char *const peerIP =
+                (pThis->fromHostIP != NULL) ? (const char *)propGetSzStr(pThis->fromHostIP) : "(IP unknown)";
+            const char *const peerPort =
+                (pThis->fromHostPort != NULL) ? (const char *)propGetSzStr(pThis->fromHostPort) : "(port unknown)";
             if (c != ' ') {
                 LogError(0, NO_ERRCODE,
                          "imtcp %s: Framing Error in received TCP message from "
-                         "peer: (hostname) %s, (ip) %s: delimiter is not SP but has "
+                         "peer: (hostname) %s, (ip) %s, (port) %s: delimiter is not SP but has "
                          "ASCII value %d.",
-                         cnf_params->pszInputName, propPeerName, propPeerIP, c);
+                         cnf_params->pszInputName, peerName, peerIP, peerPort, c);
             }
             if (pThis->iOctetsRemain < 1) {
                 /* TODO: handle the case where the octet count is 0! */
                 LogError(0, NO_ERRCODE,
                          "imtcp %s: Framing Error in received TCP message from "
-                         "peer: (hostname) %s, (ip) %s: invalid octet count %d.",
-                         cnf_params->pszInputName, propPeerName, propPeerIP, pThis->iOctetsRemain);
+                         "peer: (hostname) %s, (ip) %s, (port) %s: invalid octet count %d.",
+                         cnf_params->pszInputName, peerName, peerIP, peerPort, pThis->iOctetsRemain);
                 pThis->eFraming = TCP_FRAMING_OCTET_STUFFING;
             } else if (pThis->iOctetsRemain > pThis->iMaxLine) {
                 /* while we can not do anything against it, we can at least log an indication
@@ -522,16 +522,16 @@ static rsRetVal ATTR_NONNULL(1) processDataRcvd(tcps_sess_t *pThis,
                  */
                 LogError(0, NO_ERRCODE,
                          "imtcp %s: received oversize message from peer: "
-                         "(hostname) %s, (ip) %s: size is %d bytes, max msg size "
+                         "(hostname) %s, (ip) %s, (port) %s: size is %d bytes, max msg size "
                          "is %d, truncating...",
-                         cnf_params->pszInputName, propPeerName, propPeerIP, pThis->iOctetsRemain, pThis->iMaxLine);
+                         cnf_params->pszInputName, peerName, peerIP, peerPort, pThis->iOctetsRemain, pThis->iMaxLine);
             }
             if (pThis->iOctetsRemain > pThis->pSrv->maxFrameSize) {
                 LogError(0, NO_ERRCODE,
                          "imtcp %s: Framing Error in received TCP message from "
-                         "peer: (hostname) %s, (ip) %s: frame too large: %d, change "
+                         "peer: (hostname) %s, (ip) %s, (port) %s: frame too large: %d, change "
                          "to octet stuffing",
-                         cnf_params->pszInputName, propPeerName, propPeerIP, pThis->iOctetsRemain);
+                         cnf_params->pszInputName, peerName, peerIP, peerPort, pThis->iOctetsRemain);
                 pThis->eFraming = TCP_FRAMING_OCTET_STUFFING;
             } else {
                 pThis->iMsg = 0;


### PR DESCRIPTION
## Summary
- include the remote source port in imtcp connection open/close diagnostics emitted from tcpsrv
- extend imtcp framing error logs to report hostname, IP address, and source port together
- reuse the existing host (ip:port) formatting that TLS mismatch warnings already use for consistency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da28b9b1f483328ae12d1a06b7bcfe