### PR TITLE
ci: add omhttp Splunk HEC smoke test workflow

### DIFF
--- a/.github/workflows/omhttp-hec-smoketest.yml
+++ b/.github/workflows/omhttp-hec-smoketest.yml
@@ -1,0 +1,92 @@
+name: omhttp Splunk HEC smoke test
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/omhttp-hec-smoketest.yml'
+      - 'devtools/run-omhttp-hec-smoketest.sh'
+      - 'devtools/devcontainer.sh'
+      - 'contrib/omhttp/**'
+
+permissions:
+  contents: read
+
+jobs:
+  hec-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    services:
+      splunk:
+        image: splunk/splunk:9.2.1
+        env:
+          SPLUNK_START_ARGS: --accept-license --answer-yes --no-prompt
+          SPLUNK_PASSWORD: Changeme123!
+        ports:
+          - 8088:8088
+          - 8089:8089
+        options: >-
+          --health-cmd "/opt/splunk/bin/splunk status || exit 1"
+          --health-interval 30s
+          --health-retries 20
+          --health-timeout 30s
+          --health-start-period 120s
+    env:
+      SPLUNK_PASSWORD: Changeme123!
+      SPLUNK_HEC_TOKEN: 01234567-89ab-cdef-0123-456789abcdef
+      SPLUNK_HEC_HOST: 127.0.0.1
+      SPLUNK_HEC_PORT: 8088
+      SPLUNK_HEC_SCHEME: https
+      SPLUNK_HEC_ALLOW_UNSIGNED: on
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Wait for Splunk and enable HEC
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Waiting for Splunk service to report ready..."
+          for attempt in {1..30}; do
+            if docker exec splunk /opt/splunk/bin/splunk status 2>/dev/null | grep -q "splunkd is running"; then
+              echo "Splunk is ready"
+              break
+            fi
+            if [ "$attempt" -eq 30 ]; then
+              echo "Splunk did not report ready" >&2
+              exit 1
+            fi
+            sleep 10
+          done
+
+          docker exec splunk /opt/splunk/bin/splunk http-event-collector enable -auth "admin:${SPLUNK_PASSWORD}" >/dev/null
+          curl -sk -u "admin:${SPLUNK_PASSWORD}" https://localhost:8089/services/data/inputs/http -d name=rsyslog-gha -d token=${SPLUNK_HEC_TOKEN} -d index=main -d sourcetype=_json -d output_mode=json >/dev/null || true
+          curl -sk -u "admin:${SPLUNK_PASSWORD}" https://localhost:8089/services/data/inputs/http/rsyslog-gha -d disabled=0 >/dev/null
+
+      - name: Build rsyslog and forward sample via omhttp
+        shell: bash
+        run: |
+          set -euo pipefail
+          MESSAGE="omhttp-hec-github-action-$(date +%s)"
+          echo "OMHTTP_HEC_TEST_MESSAGE=$MESSAGE" >> "$GITHUB_ENV"
+          export OMHTTP_HEC_TEST_MESSAGE="$MESSAGE"
+          export DOCKER_RUN_EXTRA_OPTS="--network host"
+          ./devtools/devcontainer.sh --rm bash -lc "./devtools/run-omhttp-hec-smoketest.sh"
+
+      - name: Query Splunk for forwarded event
+        shell: bash
+        run: |
+          set -euo pipefail
+          SEARCH="search index=main \"${OMHTTP_HEC_TEST_MESSAGE}\" | head 1"
+          echo "Verifying Splunk search: $SEARCH"
+          for attempt in {1..30}; do
+            OUTPUT=$(docker exec splunk /opt/splunk/bin/splunk search "$SEARCH" -auth "admin:${SPLUNK_PASSWORD}" -output rawdata || true)
+            if grep -q "${OMHTTP_HEC_TEST_MESSAGE}" <<<"$OUTPUT"; then
+              echo "Found event: $OUTPUT"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "Event not found in Splunk" >&2
+          exit 1

--- a/.github/workflows/omhttp-hec-smoketest.yml
+++ b/.github/workflows/omhttp-hec-smoketest.yml
@@ -25,10 +25,10 @@ jobs:
         ports:
           - 8088:8088
           - 8089:8089
+        # The bundled Ansible bootstrap can exceed the service health timeout,
+        # so neutralise the container health check and rely on the explicit
+        # readiness probe below instead.
         options: >-
-          # The bundled Ansible bootstrap can exceed the service health timeout,
-          # so neutralise the container health check and rely on the explicit
-          # readiness probe below instead.
           --health-cmd "/bin/true"
     env:
       SPLUNK_PASSWORD: Changeme123!

--- a/.github/workflows/omhttp-hec-smoketest.yml
+++ b/.github/workflows/omhttp-hec-smoketest.yml
@@ -26,11 +26,10 @@ jobs:
           - 8088:8088
           - 8089:8089
         options: >-
-          --health-cmd "/opt/splunk/bin/splunk status || exit 1"
-          --health-interval 30s
-          --health-retries 20
-          --health-timeout 30s
-          --health-start-period 120s
+          # The bundled Ansible bootstrap can exceed the service health timeout,
+          # so neutralise the container health check and rely on the explicit
+          # readiness probe below instead.
+          --health-cmd "/bin/true"
     env:
       SPLUNK_PASSWORD: Changeme123!
       SPLUNK_HEC_TOKEN: 01234567-89ab-cdef-0123-456789abcdef
@@ -47,20 +46,44 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "Waiting for Splunk service to report ready..."
+          SPLUNK_IMAGE="splunk/splunk:9.2.1"
+          echo "Locating Splunk service container (image ${SPLUNK_IMAGE})"
           for attempt in {1..30}; do
-            if docker exec splunk /opt/splunk/bin/splunk status 2>/dev/null | grep -q "splunkd is running"; then
+            if SPLUNK_CONTAINER_ID=$(docker ps --filter "ancestor=${SPLUNK_IMAGE}" --format '{{.ID}}' | head -n1); then
+              if [ -n "${SPLUNK_CONTAINER_ID}" ]; then
+                break
+              fi
+            fi
+            if [ "$attempt" -eq 30 ]; then
+              echo "Unable to find Splunk container" >&2
+              docker ps -a
+              exit 1
+            fi
+            sleep 2
+          done
+
+          echo "SPLUNK_CONTAINER_ID=${SPLUNK_CONTAINER_ID}" >>"$GITHUB_ENV"
+
+          echo "Waiting for Splunk service to report ready..."
+          for attempt in {1..45}; do
+            if docker exec "${SPLUNK_CONTAINER_ID}" /opt/splunk/bin/splunk status 2>/dev/null | grep -q "splunkd is running"; then
               echo "Splunk is ready"
               break
             fi
-            if [ "$attempt" -eq 30 ]; then
+            if [ "$attempt" -eq 45 ]; then
               echo "Splunk did not report ready" >&2
+              docker logs "${SPLUNK_CONTAINER_ID}" | tail -n 200 || true
+              exit 1
+            fi
+            if ! docker ps --format '{{.ID}}' | grep -q "${SPLUNK_CONTAINER_ID}"; then
+              echo "Splunk container stopped unexpectedly" >&2
+              docker logs "${SPLUNK_CONTAINER_ID}" | tail -n 200 || true
               exit 1
             fi
             sleep 10
           done
 
-          docker exec splunk /opt/splunk/bin/splunk http-event-collector enable -auth "admin:${SPLUNK_PASSWORD}" >/dev/null
+          docker exec "${SPLUNK_CONTAINER_ID}" /opt/splunk/bin/splunk http-event-collector enable -auth "admin:${SPLUNK_PASSWORD}" >/dev/null
           curl -sk -u "admin:${SPLUNK_PASSWORD}" https://localhost:8089/services/data/inputs/http -d name=rsyslog-gha -d token=${SPLUNK_HEC_TOKEN} -d index=main -d sourcetype=_json -d output_mode=json >/dev/null || true
           curl -sk -u "admin:${SPLUNK_PASSWORD}" https://localhost:8089/services/data/inputs/http/rsyslog-gha -d disabled=0 >/dev/null
 
@@ -78,10 +101,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          : "${SPLUNK_CONTAINER_ID:?SPLUNK_CONTAINER_ID must be exported by the readiness step}"
           SEARCH="search index=main \"${OMHTTP_HEC_TEST_MESSAGE}\" | head 1"
           echo "Verifying Splunk search: $SEARCH"
           for attempt in {1..30}; do
-            OUTPUT=$(docker exec splunk /opt/splunk/bin/splunk search "$SEARCH" -auth "admin:${SPLUNK_PASSWORD}" -output rawdata || true)
+            OUTPUT=$(docker exec "${SPLUNK_CONTAINER_ID}" /opt/splunk/bin/splunk search "$SEARCH" -auth "admin:${SPLUNK_PASSWORD}" -output rawdata || true)
             if grep -q "${OMHTTP_HEC_TEST_MESSAGE}" <<<"$OUTPUT"; then
               echo "Found event: $OUTPUT"
               exit 0

--- a/devtools/devcontainer.sh
+++ b/devtools/devcontainer.sh
@@ -56,19 +56,25 @@ docker run $ti $optrm $DOCKER_RUN_EXTRA_OPTS \
 	-e CI_MAKE_OPT \
 	-e CI_MAKE_CHECK_OPT \
 	-e CI_CHECK_CMD \
-	-e CI_BUILD_URL \
-	-e CI_CODECOV_TOKEN \
-	-e CI_VALGRIND_SUPPRESSIONS \
-	-e CI_SANITIZE_BLACKLIST \
-	-e ABORT_ALL_ON_TEST_FAIL \
-	-e USE_AUTO_DEBUG \
-	-e RSYSLOG_STATSURL \
-	-e CODECOV_commit_sha \
-	-e CODECOV_repo_slug \
-	-e VCS_SLUG \
-	-e VERBOSE \
-	--cap-add SYS_ADMIN \
-	--cap-add SYS_PTRACE \
+        -e CI_BUILD_URL \
+        -e CI_CODECOV_TOKEN \
+        -e CI_VALGRIND_SUPPRESSIONS \
+        -e CI_SANITIZE_BLACKLIST \
+        -e ABORT_ALL_ON_TEST_FAIL \
+        -e USE_AUTO_DEBUG \
+        -e RSYSLOG_STATSURL \
+        -e CODECOV_commit_sha \
+        -e CODECOV_repo_slug \
+        -e VCS_SLUG \
+        -e VERBOSE \
+        -e SPLUNK_HEC_TOKEN \
+        -e SPLUNK_HEC_HOST \
+        -e SPLUNK_HEC_PORT \
+        -e SPLUNK_HEC_SCHEME \
+        -e SPLUNK_HEC_ALLOW_UNSIGNED \
+        -e OMHTTP_HEC_TEST_MESSAGE \
+        --cap-add SYS_ADMIN \
+        --cap-add SYS_PTRACE \
 	${RSYSLOG_CONTAINER_UID--u $(id -u):$(id -g)} \
 	$DOCKER_RUN_EXTRA_FLAGS \
 	-v "$RSYSLOG_HOME":/rsyslog $RSYSLOG_DEV_CONTAINER "$@"

--- a/devtools/run-omhttp-hec-smoketest.sh
+++ b/devtools/run-omhttp-hec-smoketest.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+##
+## run-omhttp-hec-smoketest.sh
+## ---------------------------
+## Execute a minimal omhttp-to-Splunk HEC smoke test inside the dev container.
+##
+## The script builds rsyslog with the contrib/omhttp module enabled, starts a
+## transient rsyslogd instance that tails a temporary file via imfile, forwards a
+## sample message to the configured Splunk HTTP Event Collector endpoint, and
+## shuts down again. The Splunk host, port, scheme and HEC token are read from
+## environment variables so the surrounding CI job can inject its runtime
+## configuration.
+##
+## Required environment variables:
+##   * SPLUNK_HEC_TOKEN  – authentication token to place in the Authorization
+##                          header (required)
+##
+## Optional environment variables:
+##   * SPLUNK_HEC_HOST         – hostname or IP of the HEC endpoint (default 127.0.0.1)
+##   * SPLUNK_HEC_PORT         – TCP port of the HEC endpoint (default 8088)
+##   * SPLUNK_HEC_SCHEME       – either "https" or "http" (default https)
+##   * SPLUNK_HEC_ALLOW_UNSIGNED – set to "on" to skip TLS verification when
+##                                  using https (default on)
+##   * OMHTTP_HEC_TEST_MESSAGE – payload string to send (default omhttp-hec-smoke)
+##
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+TOKEN=${SPLUNK_HEC_TOKEN:?SPLUNK_HEC_TOKEN must be set}
+HEC_HOST=${SPLUNK_HEC_HOST:-127.0.0.1}
+HEC_PORT=${SPLUNK_HEC_PORT:-8088}
+HEC_SCHEME=${SPLUNK_HEC_SCHEME:-https}
+HEC_ALLOW_UNSIGNED=${SPLUNK_HEC_ALLOW_UNSIGNED:-on}
+TEST_MESSAGE=${OMHTTP_HEC_TEST_MESSAGE:-omhttp-hec-smoke}
+
+if [ -n "${LD_LIBRARY_PATH:-}" ]; then
+    export LD_LIBRARY_PATH="${ROOT_DIR}/runtime/.libs:${ROOT_DIR}/.libs:${LD_LIBRARY_PATH}"
+else
+    export LD_LIBRARY_PATH="${ROOT_DIR}/runtime/.libs:${ROOT_DIR}/.libs"
+fi
+
+cd "$ROOT_DIR"
+
+if [ ! -x configure ]; then
+    ./autogen.sh
+fi
+
+./configure --enable-omhttp
+make -j"$(nproc)"
+
+WORK_DIR=$(mktemp -d)
+CONF_FILE="${WORK_DIR}/rsyslog-hec.conf"
+INPUT_FILE="${WORK_DIR}/hec-input.log"
+PID_FILE="${WORK_DIR}/rsyslog.pid"
+STATE_FILE="${WORK_DIR}/hec-input.state"
+
+cat <<CFG >"$CONF_FILE"
+module(load="${ROOT_DIR}/plugins/imfile/.libs/imfile")
+module(load="${ROOT_DIR}/contrib/omhttp/.libs/omhttp")
+
+global(
+    workDirectory="${WORK_DIR}"
+)
+
+template(name="splunk-hec-jsonf" type="list" subtype="jsonf") {
+    property(outname="event" name="msg")
+    property(outname="host" name="hostname")
+    property(outname="time" name="timereported" dateFormat="unixtimestamp")
+    property(outname="severity" name="syslogseverity-text")
+    property(outname="facility" name="syslogfacility-text")
+    property(outname="app" name="app-name")
+}
+
+input(
+    type="imfile"
+    File="${INPUT_FILE}"
+    Tag="hec-smoke"
+    PersistStateInterval="1"
+    statefile="${STATE_FILE}"
+)
+
+action(
+    type="omhttp"
+    name="send_to_splunk_hec"
+    server="${HEC_HOST}"
+    serverport="${HEC_PORT}"
+    restpath="services/collector/event"
+    template="splunk-hec-jsonf"
+    batch="off"
+    action.resumeRetryCount="-1"
+    httpheaderkey="Authorization"
+    httpheadervalue="Splunk ${TOKEN}"
+CFG
+
+if [ "$HEC_SCHEME" = "https" ]; then
+    cat <<CFG >>"$CONF_FILE"
+    usehttps="on"
+    allowunsignedcerts="${HEC_ALLOW_UNSIGNED}"
+CFG
+else
+    cat <<CFG >>"$CONF_FILE"
+    usehttps="off"
+CFG
+fi
+
+cat <<'CFG' >>"$CONF_FILE"
+)
+CFG
+
+: >"$INPUT_FILE"
+
+./tools/rsyslogd -N1 -f "$CONF_FILE"
+./tools/rsyslogd -n -f "$CONF_FILE" -i "$PID_FILE" &
+RSYSLOG_PID=$!
+trap 'kill "$RSYSLOG_PID" 2>/dev/null || true' EXIT
+
+sleep 3
+echo "$TEST_MESSAGE" >>"$INPUT_FILE"
+
+for _ in {1..30}; do
+    if ! kill -0 "$RSYSLOG_PID" 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done
+
+if kill -0 "$RSYSLOG_PID" 2>/dev/null; then
+    kill "$RSYSLOG_PID"
+fi
+
+set +e
+wait "$RSYSLOG_PID"
+STATUS=$?
+set -e
+trap - EXIT
+
+if [ "$STATUS" -ne 0 ] && [ "$STATUS" -ne 143 ]; then
+    exit "$STATUS"
+fi
+
+rm -rf "$WORK_DIR"


### PR DESCRIPTION
## Summary
- add a GitHub Action that provisions Splunk HEC, pushes sample data with omhttp, and verifies the event via search
- provide a helper script to build rsyslog in the dev container and forward the message using the existing jsonf template
- forward Splunk-specific environment variables through devtools/devcontainer.sh so the smoke test can pass runtime parameters

## Testing
- not run (workflow definition only)


------
https://chatgpt.com/codex/tasks/task_e_68dbbc81f8288332b82436fa167ffb0c