### PR TITLE
Add HEC validation mode to omhttp test server harness

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1010,10 +1010,11 @@ TESTS +=  \
 	omhttp-batch-jsonarray.sh \
 	omhttp-batch-kafkarest-retry.sh \
 	omhttp-batch-kafkarest.sh \
-	omhttp-batch-lokirest-retry.sh \
-	omhttp-batch-lokirest.sh \
-	omhttp-profile-loki.sh \
-	omhttp-batch-newline.sh \
+        omhttp-batch-lokirest-retry.sh \
+        omhttp-batch-lokirest.sh \
+        omhttp-profile-hec-splunk.sh \
+        omhttp-profile-loki.sh \
+        omhttp-batch-newline.sh \
 	omhttp-retry.sh \
 	omhttp-retry-timeout.sh \
 	omhttp-httpheaderkey.sh \
@@ -2774,11 +2775,12 @@ EXTRA_DIST= \
 	omhttp-batch-jsonarray.sh \
 	omhttp-batch-kafkarest-retry.sh \
 	omhttp-batch-kafkarest.sh \
-	omhttp-batch-lokirest-retry.sh \
-	omhttp-batch-lokirest.sh \
-	omhttp-batch-lokirest-vg.sh \
-	omhttp-profile-loki.sh \
-	omhttp-batch-newline.sh \
+        omhttp-batch-lokirest-retry.sh \
+        omhttp-batch-lokirest.sh \
+        omhttp-batch-lokirest-vg.sh \
+        omhttp-profile-hec-splunk.sh \
+        omhttp-profile-loki.sh \
+        omhttp-batch-newline.sh \
 	omhttp-batch-retry-metadata.sh \
 	omhttp-retry-timeout.sh \
 	omhttp-basic-ignorecodes-vg.sh \

--- a/tests/README
+++ b/tests/README
@@ -53,6 +53,27 @@ iteration, though Automake will not capture transcripts.
   Valgrind. Some legacy wrappers predate this pattern; follow the newer style
   when adding or refactoring coverage.
 
+## omhttp test server helpers
+
+The lightweight HTTP listener in `tests/omhttp_server.py` powers many output
+module scenarios. `diag.sh` exposes `omhttp_start_server`,
+`omhttp_get_data`, and `omhttp_stop_server` to manage it from tests.
+
+- `omhttp_get_data <port> <path> <format>` now returns the stored batches along
+  with parsed summaries. The optional `<format>` argument accepts the previous
+  values (`jsonarray`, `newline`, `kafkarest`, `lokirest`) and adds `hec` for
+  Splunk HEC payloads.
+- Starting the server with `--validate-hec` enables strict HEC validation. The
+  helper accepts additional knobs to simulate client retries:
+  - `--hec-validation-error-code` and `--hec-validation-error-message` control
+    the 4xx response for malformed payloads.
+  - `--hec-fail-after <n>` and `--hec-fail-every <n>` produce deterministic 4xx
+    responses even for valid payloads.
+  - `--hec-fail-message` customises the simulated validation failure body.
+- When HEC validation is active, the server records both the raw POST body and a
+  parsed summary (including extracted `msgnum` values) so callers can inspect
+  either representation.
+
 ## Environment setup snippets
 
 ### MariaDB/MySQL

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2848,37 +2848,82 @@ omhttp_get_data() {
         omhttp_path=$2
     fi
 
-    # The test server returns a json encoded array of strings containing whatever omhttp sent to it in each request
-    python_init="import json, sys; dat = json.load(sys.stdin)"
-    python_print="print('\n'.join(out))"
-    if [ "x$3" == "x" ]; then
-        # dat = ['{"msgnum":"1"}, '{"msgnum":"2"}', '{"msgnum":"3"}', '{"msgnum":"4"}']
-        python_parse="$python_init; out = [json.loads(l)['msgnum'] for l in dat]; $python_print"
-    else
-       if [ "x$3" == "xjsonarray" ]; then
-            # dat = ['[{"msgnum":"1"},{"msgnum":"2"}]', '[{"msgnum":"3"},{"msgnum":"4"}]']
-            python_parse="$python_init; out = [l['msgnum'] for a in dat for l in json.loads(a)]; $python_print"
-        elif [ "x$3" == "xnewline" ]; then
-            # dat = ['{"msgnum":"1"}\n{"msgnum":"2"}', '{"msgnum":"3"}\n{"msgnum":"4"}']
-            python_parse="$python_init; out = [json.loads(l)['msgnum'] for a in dat for l in a.split('\n')]; $python_print"
-        elif [ "x$3" == "xkafkarest" ]; then
-            # dat = ['{"records":[{"value":{"msgnum":"1"}},{"value":{"msgnum":"2"}}]}',
-            #        '{"records":[{"value":{"msgnum":"3"}},{"value":{"msgnum":"4"}}]}']
-            python_parse="$python_init; out = [l['value']['msgnum'] for a in dat for l in json.loads(a)['records']]; $python_print"
-        elif [ "x$3" == "xlokirest" ]; then
-            # dat = ['{"streams":[{"msgnum":"1"},{"msgnum":"2"}]}',
-            #        '{"streams":[{"msgnum":"3"},{"msgnum":"4"}]}']
-            python_parse="$python_init; out = [l['msgnum'] for a in dat for l in json.loads(a)['streams']]; $python_print"
-        else
-            # use newline parsing as default
-            python_parse="$python_init; out = [json.loads(l)['msgnum'] for a in dat for l in a.split('\n')]; $python_print"
-        fi
-
-    fi
+    python_parse='import json, sys\n'
+    python_parse+='fmt = sys.argv[1] if len(sys.argv) > 1 else ""\n'
+    python_parse+='data = json.load(sys.stdin)\n'
+    python_parse+='try:\n'
+    python_parse+='    string_types = (str, bytes)\n'
+    python_parse+='except NameError:\n'
+    python_parse+='    string_types = (str,)\n'
+    python_parse+='def ensure_list(val):\n'
+    python_parse+='    if isinstance(val, list):\n'
+    python_parse+='        return val\n'
+    python_parse+='    return [val]\n'
+    python_parse+='def extract_from_obj(obj, out):\n'
+    python_parse+='    if isinstance(obj, dict):\n'
+    python_parse+='        if "msgnum" in obj:\n'
+    python_parse+='            out.append(str(obj["msgnum"]))\n'
+    python_parse+='        if "value" in obj:\n'
+    python_parse+='            extract_from_obj(obj["value"], out)\n'
+    python_parse+='        if "streams" in obj and isinstance(obj["streams"], list):\n'
+    python_parse+='            for item in obj["streams"]:\n'
+    python_parse+='                extract_from_obj(item, out)\n'
+    python_parse+='        if "records" in obj and isinstance(obj["records"], list):\n'
+    python_parse+='            for item in obj["records"]:\n'
+    python_parse+='                extract_from_obj(item, out)\n'
+    python_parse+='        if "event" in obj:\n'
+    python_parse+='            event_value = obj["event"]\n'
+    python_parse+='            if isinstance(event_value, string_types):\n'
+    python_parse+='                try:\n'
+    python_parse+='                    event_value = json.loads(event_value)\n'
+    python_parse+='                except (TypeError, ValueError):\n'
+    python_parse+='                    event_value = None\n'
+    python_parse+='            extract_from_obj(event_value, out)\n'
+    python_parse+='    elif isinstance(obj, list):\n'
+    python_parse+='        for item in obj:\n'
+    python_parse+='            extract_from_obj(item, out)\n'
+    python_parse+='def extract_msgnums(raw):\n'
+    python_parse+='    nums = []\n'
+    python_parse+='    try:\n'
+    python_parse+='        parsed = json.loads(raw)\n'
+    python_parse+='    except (TypeError, ValueError):\n'
+    python_parse+='        for line in raw.splitlines():\n'
+    python_parse+='            line = line.strip()\n'
+    python_parse+='            if not line:\n'
+    python_parse+='                continue\n'
+    python_parse+='            try:\n'
+    python_parse+='                parsed_line = json.loads(line)\n'
+    python_parse+='            except (TypeError, ValueError):\n'
+    python_parse+='                continue\n'
+    python_parse+='            extract_from_obj(parsed_line, nums)\n'
+    python_parse+='    else:\n'
+    python_parse+='        extract_from_obj(parsed, nums)\n'
+    python_parse+='    return nums\n'
+    python_parse+='def parse_entry(entry):\n'
+    python_parse+='    if isinstance(entry, dict):\n'
+    python_parse+='        summary = entry.get("summary", {})\n'
+    python_parse+='        if isinstance(summary, dict):\n'
+    python_parse+='            msgnums = summary.get("msgnums")\n'
+    python_parse+='            if msgnums:\n'
+    python_parse+='                return [str(v) for v in ensure_list(msgnums)]\n'
+    python_parse+='            if fmt == "hec" and summary.get("hec_events"):\n'
+    python_parse+='                extracted = []\n'
+    python_parse+='                for ev in summary.get("hec_events") or []:\n'
+    python_parse+='                    extract_from_obj(ev, extracted)\n'
+    python_parse+='                if extracted:\n'
+    python_parse+='                    return extracted\n'
+    python_parse+='        raw = entry.get("raw", "")\n'
+    python_parse+='    else:\n'
+    python_parse+='        raw = entry\n'
+    python_parse+='    return [str(v) for v in extract_msgnums(raw)]\n'
+    python_parse+='out = []\n'
+    python_parse+='for item in data:\n'
+    python_parse+='    out.extend(parse_entry(item))\n'
+    python_parse+='print("\\n".join(out))\n'
 
     omhttp_url="localhost:${omhttp_server_port}/${omhttp_path}"
     curl -s ${omhttp_url} \
-        | $PYTHON -c "${python_parse}" | sort -n \
+        | $PYTHON -c "${python_parse}" "$3" | sort -n \
         > ${RSYSLOG_OUT_LOG}
 }
 

--- a/tests/omhttp-profile-hec-splunk.sh
+++ b/tests/omhttp-profile-hec-splunk.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+## @brief Exercise the omhttp test server's HEC validation helpers
+# This file is part of the rsyslog project, released under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+
+hec_endpoint="services/collector/event"
+
+# Enable HEC validation and force a deterministic retry failure after the first success
+omhttp_start_server 0 \
+    --validate-hec \
+    --hec-fail-after 1 \
+    --hec-fail-message 'intentional hec validation failure'
+
+send_hec_request() {
+    local body="$1"
+    local outfile="$2"
+    curl -s -o "$outfile" -w "%{http_code}" \
+        -H 'Content-Type: application/json' \
+        --data "$body" \
+        "http://localhost:${omhttp_server_lstnport}/${hec_endpoint}"
+}
+
+valid_payload_one='{"event":{"msgnum":"0"},"host":"testbench"}'
+valid_payload_two='{"event":{"msgnum":"1"},"host":"testbench"}'
+invalid_payload='{"host":"testbench"}'
+
+response_file="$RSYSLOG_DYNNAME/hec-response.json"
+mkdir -p "$RSYSLOG_DYNNAME"
+
+status=$(send_hec_request "$valid_payload_one" "$response_file")
+if [ "$status" != "200" ]; then
+    echo "expected first payload to succeed, got HTTP $status"
+    cat "$response_file"
+    error_exit 1
+fi
+
+status=$(send_hec_request "$valid_payload_two" "$response_file")
+if [ "$status" != "400" ]; then
+    echo "expected second payload to fail with simulated validation error, got HTTP $status"
+    cat "$response_file"
+    error_exit 1
+fi
+if ! grep -q 'intentional hec validation failure' "$response_file"; then
+    echo "missing simulated failure message in response"
+    cat "$response_file"
+    error_exit 1
+fi
+
+status=$(send_hec_request "$invalid_payload" "$response_file")
+if [ "$status" != "400" ]; then
+    echo "expected malformed payload to fail validation, got HTTP $status"
+    cat "$response_file"
+    error_exit 1
+fi
+if ! grep -q 'missing required "event" field' "$response_file"; then
+    echo "validation error response did not mention missing event"
+    cat "$response_file"
+    error_exit 1
+fi
+
+# Only the first, valid payload should be stored.
+omhttp_get_data "$omhttp_server_lstnport" "$hec_endpoint" hec
+EXPECTED="0"
+cmp_exact "$RSYSLOG_OUT_LOG"
+
+omhttp_stop_server
+exit_test

--- a/tests/omhttp_server.py
+++ b/tests/omhttp_server.py
@@ -15,20 +15,141 @@ except ImportError:
 # Keep track of data received at each path
 data = {}
 
-metadata = {'posts': 0, 'fail_after': 0, 'fail_every': -1, 'decompress': False, 'userpwd': ''}
+metadata = {
+    'posts': 0,
+    'fail_after': 0,
+    'fail_every': -1,
+    'decompress': False,
+    'userpwd': '',
+    'validate_hec': False,
+    'hec_validation_error_code': 400,
+    'hec_validation_error_message': 'invalid HEC payload',
+    'hec_fail_after': -1,
+    'hec_fail_every': -1,
+    'hec_fail_message': 'simulated HEC format error',
+}
+
+
+try:
+    JSONDecodeError = json.JSONDecodeError
+except AttributeError:  # pragma: no cover - python2 compatibility
+    JSONDecodeError = ValueError
+
+try:
+    basestring
+except NameError:  # pragma: no cover - python3 compatibility
+    basestring = (str, bytes)
+
+
+def _extract_msgnums_from_obj(obj, msgnums):
+    """Helper to recursively gather msgnum values from nested payloads."""
+    if isinstance(obj, dict):
+        if 'msgnum' in obj:
+            msgnums.append(obj['msgnum'])
+        if 'value' in obj:
+            _extract_msgnums_from_obj(obj['value'], msgnums)
+        if 'streams' in obj and isinstance(obj['streams'], list):
+            for item in obj['streams']:
+                _extract_msgnums_from_obj(item, msgnums)
+        if 'records' in obj and isinstance(obj['records'], list):
+            for item in obj['records']:
+                _extract_msgnums_from_obj(item, msgnums)
+        if 'event' in obj:
+            event_obj = obj['event']
+            if isinstance(event_obj, basestring):  # type: ignore[name-defined]
+                try:
+                    event_obj = json.loads(event_obj)
+                except (ValueError, TypeError):
+                    event_obj = None
+            _extract_msgnums_from_obj(event_obj, msgnums)
+    elif isinstance(obj, list):
+        for item in obj:
+            _extract_msgnums_from_obj(item, msgnums)
+
+
+def extract_msgnums(raw_data):
+    msgnums = []
+    try:
+        parsed = json.loads(raw_data)
+    except (ValueError, TypeError):
+        for line in raw_data.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                parsed_line = json.loads(line)
+            except (ValueError, TypeError):
+                continue
+            _extract_msgnums_from_obj(parsed_line, msgnums)
+    else:
+        _extract_msgnums_from_obj(parsed, msgnums)
+    return msgnums
+
+
+def validate_hec_payload(raw_data):
+    summary = {'msgnums': []}
+    events = []
+    try:
+        payload = json.loads(raw_data)
+    except (ValueError, TypeError, JSONDecodeError):
+        payload = None
+
+    decoded_entries = []
+
+    if isinstance(payload, dict):
+        decoded_entries = [payload]
+    elif isinstance(payload, list):
+        decoded_entries = payload
+    else:
+        decoded_entries = []
+
+    if not decoded_entries:
+        lines = [line.strip() for line in raw_data.split('\n') if line.strip()]
+        for line in lines:
+            try:
+                decoded_entries.append(json.loads(line))
+            except (ValueError, TypeError, JSONDecodeError):
+                return False, 'invalid JSON payload for HEC validation', summary
+
+    for entry in decoded_entries:
+        if not isinstance(entry, dict):
+            return False, 'HEC payload entries must be JSON objects', summary
+        if 'event' not in entry:
+            return False, 'HEC payload missing required "event" field', summary
+        event_value = entry['event']
+        events.append(entry)
+        if isinstance(event_value, dict) and 'msgnum' in event_value:
+            summary['msgnums'].append(event_value['msgnum'])
+        elif isinstance(event_value, basestring):  # type: ignore[name-defined]
+            try:
+                event_json = json.loads(event_value)
+                _extract_msgnums_from_obj(event_json, summary['msgnums'])
+            except (ValueError, TypeError):
+                pass
+        elif isinstance(event_value, list):
+            _extract_msgnums_from_obj(event_value, summary['msgnums'])
+
+    summary['hec_events'] = events
+    if not summary['msgnums']:
+        summary['msgnums'] = extract_msgnums(raw_data)
+    return True, '', summary
 
 
 class MyHandler(BaseHTTPRequestHandler):
     """
     POST'd data is kept in the data global dict.
-    Keys are the path, values are the raw received data.
-    Two post requests to <host>:<port>/post/endpoint means data looks like...
-        {"/post/endpoint": ["{\"msgnum\":\"00001\"}", "{\"msgnum\":\"00001\"}"]}
+    Keys are the path, values are dictionaries containing the raw payload and
+    extracted metadata. Two post requests to
+    <host>:<port>/post/endpoint means data looks like...
+        {"/post/endpoint": [
+            {"raw": "{\\"msgnum\\":\\"00001\\"}", "summary": {"msgnums": ["00001"]}},
+            {"raw": "{\\"msgnum\\":\\"00002\\"}", "summary": {"msgnums": ["00002"]}}
+        ]}
 
-    GET requests return all data posted to that endpoint as a json list.
-    Note that rsyslog usually sends escaped json data, so some parsing may be needed.
-    A get request for <host>:<post>/post/endpoint responds with...
-        ["{\"msgnum\":\"00001\"}", "{\"msgnum\":\"00001\"}"]
+    GET requests return all data posted to that endpoint as a json list of
+    objects. Each object contains `raw` and `summary` keys so callers can select
+    the representation they need. `summary` typically includes a `msgnums`
+    array.
     """
 
     def validate_auth(self):
@@ -92,9 +213,25 @@ class MyHandler(BaseHTTPRequestHandler):
         else:
             post_data = raw_data
 
+        decoded_payload = post_data.decode('utf-8')
+        summary = {'msgnums': extract_msgnums(decoded_payload)}
+
+        if metadata['validate_hec']:
+            is_valid, reason, hec_summary = validate_hec_payload(decoded_payload)
+            if not is_valid:
+                validation_msg = metadata['hec_validation_error_message']
+                if reason:
+                    validation_msg = '{0}: {1}'.format(validation_msg, reason)
+                self._send_hec_error(validation_msg)
+                return
+            summary.update(hec_summary)
+            if self._should_fail_hec_injection():
+                self._send_hec_error(metadata['hec_fail_message'])
+                return
+
         if self.path not in data:
             data[self.path] = []
-        data[self.path].append(post_data.decode('utf-8'))
+        data[self.path].append({'raw': decoded_payload, 'summary': summary})
 
         res = json.dumps({'msg': 'ok'}).encode('utf8')
 
@@ -105,6 +242,32 @@ class MyHandler(BaseHTTPRequestHandler):
 
         self.wfile.write(res)
         return
+
+    def _send_hec_error(self, message):
+        try:
+            code = int(metadata['hec_validation_error_code'])
+        except (TypeError, ValueError):
+            code = 400
+        if code < 400 or code > 499:
+            code = 400
+        payload = json.dumps({'error': message}).encode('utf8')
+        self.send_response(code)
+        self.send_header('Content-Type', 'application/json; charset=utf-8')
+        self.send_header('Content-Length', len(payload))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _should_fail_hec_injection(self):
+        if not metadata['validate_hec']:
+            return False
+        posts = metadata['posts']
+        fail_after = metadata.get('hec_fail_after', -1)
+        fail_every = metadata.get('hec_fail_every', -1)
+        if fail_after != -1 and posts > fail_after:
+            return True
+        if fail_every != -1 and posts > 0 and posts % fail_every == 0:
+            return True
+        return False
 
     def do_GET(self):
         if self.path in data:
@@ -136,6 +299,12 @@ if __name__ == '__main__':
     parser.add_argument('--fail-with-delay-secs', action='store', type=int, default=0, help='fail with n secs of delay')
     parser.add_argument('--decompress', action='store_true', default=False, help='decompress posted data')
     parser.add_argument('--userpwd', action='store', default='', help='only accept this user:password combination')
+    parser.add_argument('--validate-hec', action='store_true', default=False, help='validate payloads as Splunk HEC events')
+    parser.add_argument('--hec-validation-error-code', action='store', type=int, default=400, help='HTTP code for HEC validation failures')
+    parser.add_argument('--hec-validation-error-message', action='store', default='invalid HEC payload', help='Message returned when HEC validation fails')
+    parser.add_argument('--hec-fail-after', action='store', type=int, default=-1, help='after n posts, simulate HEC validation failure')
+    parser.add_argument('--hec-fail-every', action='store', type=int, default=-1, help='every n posts, simulate HEC validation failure')
+    parser.add_argument('--hec-fail-message', action='store', default='simulated HEC format error', help='error message for simulated HEC failures')
     args = parser.parse_args()
     metadata['fail_after'] = args.fail_after
     metadata['fail_every'] = args.fail_every
@@ -145,6 +314,12 @@ if __name__ == '__main__':
     metadata['fail_with_delay_secs'] = args.fail_with_delay_secs
     metadata['decompress'] = args.decompress
     metadata['userpwd'] = args.userpwd
+    metadata['validate_hec'] = args.validate_hec
+    metadata['hec_validation_error_code'] = args.hec_validation_error_code
+    metadata['hec_validation_error_message'] = args.hec_validation_error_message
+    metadata['hec_fail_after'] = args.hec_fail_after
+    metadata['hec_fail_every'] = args.hec_fail_every
+    metadata['hec_fail_message'] = args.hec_fail_message
     server = HTTPServer((args.interface, args.port), MyHandler)
     lstn_port = server.server_address[1]
     pid = os.getpid()


### PR DESCRIPTION
## Summary
- extend the omhttp test server with Splunk HEC validation, deterministic failure injection, and raw+summary storage for requests
- update diag.sh and README to consume the new response layout and expose the `hec` batch format when collecting batches
- add omhttp-profile-hec-splunk.sh and register it in the test suite to exercise accept and reject paths

## Testing
- python3 -m py_compile tests/omhttp_server.py
- manual curl validation of HEC success/failure responses


------
https://chatgpt.com/codex/tasks/task_e_68dcffca38a883329a0b6bc1854e9e1d