### PR TITLE
Add config.defaults.version compatibility option

### DIFF
--- a/doc/source/rainerscript/global.rst
+++ b/doc/source/rainerscript/global.rst
@@ -523,6 +523,22 @@ The following parameters can be set:
   need to switch it back to "on", except for the case to be mentioned.
   This is also the reason why we switched the default.
 
+- **config.defaults.version** [YYMM] available 8.2508.0+
+
+  **Default:** ``0302`` (rsyslog February 2003 compatibility baseline)
+
+  Sets the release vintage whose built-in defaults rsyslog should emulate.
+  The value must be a four-digit ``YYMM`` string matching the "minor" portion
+  of an rsyslog version (for example ``2304`` for v8.2304.x).  Months must be
+  between ``01`` and ``12``; any other value triggers a configuration error and
+  leaves the previous compatibility level in place.  By default rsyslog keeps
+  the oldest available behaviour (February 2003) until the administrator opts
+  into a newer baseline.  This knob prepares rsyslog to offer modernized
+  defaults for new installations while letting existing deployments lock
+  themselves to an older baseline.  As of v8.2508.0 the value
+  is parsed and stored for future use; later releases will consume it to adjust
+  default behavior.
+
 - **internal.developeronly.options**
 
   This is NOT to be used by end users. It provides rsyslog developers the

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -169,6 +169,7 @@ static struct cnfparamdescr cnfparamdescr[] = {
     {"abortonuncleanconfig", eCmdHdlrBinary, 0},
     {"abortonfailedqueuestartup", eCmdHdlrBinary, 0},
     {"variables.casesensitive", eCmdHdlrBinary, 0},
+    {"config.defaults.version", eCmdHdlrGetWord, 0},
     {"environment", eCmdHdlrArray, 0},
     {"processinternalmessages", eCmdHdlrBinary, 0},
     {"umask", eCmdHdlrFileCreateMode, 0},
@@ -407,6 +408,45 @@ static rsRetVal setWorkDir(void __attribute__((unused)) * pVal, uchar *pNewVal) 
 
 finalize_it:
     RETiRet;
+}
+
+
+static void configDefaultsVersionApply(const char *const value) {
+    if (value == NULL) return;
+
+    const unsigned int prevYear = loadConf->defaults.configDefaultsYear;
+    const unsigned int prevMonth = loadConf->defaults.configDefaultsMonth;
+
+    const size_t len = strlen(value);
+    if (len != 4U) {
+        parser_errmsg(
+            "config.defaults.version must be a 4-digit YYMM value; invalid value '%s' ignored (keeping %02u%02u)",
+            value, prevYear, prevMonth);
+        return;
+    }
+
+    for (size_t i = 0; i < len; ++i) {
+        if (!isdigit((unsigned char)value[i])) {
+            parser_errmsg(
+                "config.defaults.version must contain only digits; invalid value '%s' ignored (keeping %02u%02u)",
+                value, prevYear, prevMonth);
+            return;
+        }
+    }
+
+    const int yy = (value[0] - '0') * 10 + (value[1] - '0');
+    const int mm = (value[2] - '0') * 10 + (value[3] - '0');
+    if (mm < 1 || mm > 12) {
+        parser_errmsg(
+            "config.defaults.version requires a month between 01 and 12; invalid value '%s' ignored (keeping %02u%02u)",
+            value, prevYear, prevMonth);
+        return;
+    }
+
+    loadConf->defaults.configDefaultsVersion = (unsigned int)((yy * 100) + mm);
+    loadConf->defaults.configDefaultsYear = (unsigned int)yy;
+    loadConf->defaults.configDefaultsMonth = (unsigned int)mm;
+    loadConf->defaults.configDefaultsVersionExplicit = 1;
 }
 
 
@@ -1006,6 +1046,10 @@ static rsRetVal resetConfigVariables(uchar __attribute__((unused)) * pp, void __
     loadConf->globals.parser.bEscape8BitChars = 0; /* default is not to escape control characters */
     loadConf->globals.parser.bEscapeTab = 1; /* default is to escape tab characters */
     loadConf->globals.parser.bParserEscapeCCCStyle = 0;
+    loadConf->defaults.configDefaultsVersion = RSYSLOG_CONFIG_DEFAULTS_VERSION;
+    loadConf->defaults.configDefaultsYear = RSYSLOG_CONFIG_DEFAULTS_VERSION_YEAR;
+    loadConf->defaults.configDefaultsMonth = RSYSLOG_CONFIG_DEFAULTS_VERSION_MONTH;
+    loadConf->defaults.configDefaultsVersionExplicit = 0;
 #ifdef USE_UNLIMITED_SELECT
     iFdSetSize = howmany(FD_SETSIZE, __NFDBITS) * sizeof(fd_mask);
 #endif
@@ -1210,6 +1254,10 @@ rsRetVal glblDoneLoadCnf(void) {
             const int val = (int)cnfparamvals[i].val.d.n;
             fjson_global_do_case_sensitive_comparison(val);
             DBGPRINTF("global/config: set case sensitive variables to %d\n", val);
+        } else if (!strcmp(paramblk.descr[i].name, "config.defaults.version")) {
+            char *const version = es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
+            configDefaultsVersionApply(version);
+            free(version);
         } else if (!strcmp(paramblk.descr[i].name, "localhostname")) {
             free(LocalHostNameOverride);
             LocalHostNameOverride = (uchar *)es_str2cstr(cnfparamvals[i].val.d.estr, NULL);

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -211,6 +211,10 @@ static void cnfSetDefaults(rsconf_t *pThis) {
     pThis->globals.internalMsgRatelimitCfg = NULL;
     pThis->globals.intMsgsSeverityFilter = DFLT_INT_MSGS_SEV_FILTER;
     pThis->globals.permitCtlC = glblPermitCtlC;
+    pThis->defaults.configDefaultsVersion = RSYSLOG_CONFIG_DEFAULTS_VERSION;
+    pThis->defaults.configDefaultsYear = RSYSLOG_CONFIG_DEFAULTS_VERSION_YEAR;
+    pThis->defaults.configDefaultsMonth = RSYSLOG_CONFIG_DEFAULTS_VERSION_MONTH;
+    pThis->defaults.configDefaultsVersionExplicit = 0;
     ratelimitStoreInit(pThis);
 
     pThis->globals.actq_dflt_toQShutdown = 10;

--- a/runtime/rsconf.h
+++ b/runtime/rsconf.h
@@ -43,6 +43,19 @@
     #define DFLT_INT_MSGS_SEV_FILTER 6 /* Warning level and more important */
 #endif
 
+/*
+ * Global configuration default compatibility window.  The value represents
+ * the "minor" part of the rsyslog version string (YYMM).  Update the
+ * constants whenever the defaults shipped with rsyslog are adjusted for a
+ * new release series.  The default remains pinned to February 2003 so that
+ * fresh installs emulate the oldest available behaviour unless the user
+ * explicitly opts into a newer baseline.
+ */
+#define RSYSLOG_CONFIG_DEFAULTS_VERSION_YEAR 3
+#define RSYSLOG_CONFIG_DEFAULTS_VERSION_MONTH 2
+#define RSYSLOG_CONFIG_DEFAULTS_VERSION \
+    ((RSYSLOG_CONFIG_DEFAULTS_VERSION_YEAR * 100) + RSYSLOG_CONFIG_DEFAULTS_VERSION_MONTH)
+
 struct queuecnf_s {
     int iMainMsgQueueSize; /* size of the main message queue above */
     int iMainMsgQHighWtrMark; /* high water mark for disk-assisted queues */
@@ -187,7 +200,10 @@ struct globals_s {
  * At a later stage, we may think about dropping them. -- rgerhards, 2011-04-19
  */
 struct defaults_s {
-    int remove_me_when_first_real_member_is_added;
+    unsigned int configDefaultsVersion; /* Combined YYMM representation. */
+    unsigned int configDefaultsYear;    /* Two-digit year component. */
+    unsigned int configDefaultsMonth;   /* Month component (1-12). */
+    int configDefaultsVersionExplicit;  /* Was the value provided by config? */
 };
 
 


### PR DESCRIPTION
## Summary
- add a `config.defaults.version` global option that records the release baseline for built-in defaults
- validate the YYMM input, keep the default pinned to February 2003 compatibility, and store the parsed metadata on the configuration defaults
- document the new knob in the Rainerscript `global()` reference

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e125b1ca588332860ee1898f18c1eb