### PR TITLE
Update tutorials to Rainerscript syntax

### DIFF
--- a/doc/source/tutorials/log_rotation_fix_size.rst
+++ b/doc/source/tutorials/log_rotation_fix_size.rst
@@ -19,27 +19,29 @@ your logs at a given size. The following sample is based on rsyslog
 illustrating a simple but effective log rotation with a maximum size
 condition.
 
-Use Output Channels for fixed-length syslog files
--------------------------------------------------
+Use Rainerscript rotation parameters for fixed-length syslog files
+------------------------------------------------------------------
 
 Lets assume you do not want to spend more than 100 MB hard disc space
-for you logs. With rsyslog you can configure Output Channels to achieve
-this. Putting the following directive
+for you logs. With rsyslog you can configure the
+``rotation.sizeLimit`` and ``rotation.sizeLimitCommand`` parameters of
+the :doc:`omfile action <../configuration/modules/omfile>` to achieve
+this. The Rainerscript fragment below writes all messages to a file and
+rotates it once the size limit is exceeded.
 
-::
+.. code-block:: rsyslog
 
-    # start log rotation via outchannel
-    # outchannel definition
-    $outchannel log_rotation,/var/log/log_rotation.log, 52428800,/home/me/./log_rotation_script 
-    #  activate the channel and log everything to it 
-    *.* :omfile:$log_rotation
-    # end log rotation via outchannel
+    action(
+        type="omfile"
+        file="/var/log/log_rotation.log"
+        rotation.sizeLimit="52428800"        # 50 MiB per file
+        rotation.sizeLimitCommand="/home/me/log_rotation_script"
+        template="RSYSLOG_TraditionalFileFormat"
+    )
 
-to rsyslog.conf instruct rsyslog to log everything to the destination
-file '/var/log/log\_rotation.log' until the give file size of 50 MB is
-reached. If the max file size is reached it will perform an action. In
-our case it executes the script /home/me/log\_rotation\_script which
-contains a single command:
+When the configured limit is reached, rsyslog executes the command
+specified in ``rotation.sizeLimitCommand``. In our case it runs
+``/home/me/log_rotation_script`` which contains a single command:
 
 ::
 
@@ -47,8 +49,18 @@ contains a single command:
 
 This moves the original log to a kind of backup log file. After the
 action was successfully performed rsyslog creates a new
-/var/log/log\_rotation.log file and fill it up with new logs. So the
-latest logs are always in log\_rotation.log.
+``/var/log/log_rotation.log`` file and fills it with new logs. So the
+latest logs are always in ``log_rotation.log``. The two rotation
+parameters are documented in
+:doc:`../reference/parameters/omfile-rotation-sizelimit` and
+:doc:`../reference/parameters/omfile-rotation-sizelimitcommand`.
+
+.. note::
+
+   Older examples use the ``$outchannel`` directive. That syntax maps to
+   the same rotation parameters shown above but is kept solely for
+   backward compatibility. New configurations should always use
+   Rainerscript objects and attributes.
 
 Conclusion
 ----------

--- a/doc/source/tutorials/reliable_forwarding.rst
+++ b/doc/source/tutorials/reliable_forwarding.rst
@@ -64,25 +64,33 @@ simple config file, you forward anything you receive to a remote server
 and have buffering applied automatically when it goes down. This must be
 done on the client machine.
 
-.. code-block:: linux-config
+.. code-block:: rsyslog
 
-    $ModLoad imuxsock # local message reception
-    $WorkDirectory /rsyslog/work # default location for work (spool) files
-    $ActionQueueType LinkedList # use asynchronous processing
-    $ActionQueueFileName srvrfwd # set file name, also enables disk mode
-    $ActionResumeRetryCount -1 # infinite retries on insert failure
-    $ActionQueueSaveOnShutdown on # save in-memory data if rsyslog shuts down 
-    *.* @@server:port
+    module(load="imuxsock")            # local message reception
+    global(workDirectory="/rsyslog/work")
 
-The port given above is optional. It may not be specified, in which case
-you only provide the server name. The "$ActionQueueFileName" is used to
-create queue files, should need arise. This value must be unique inside
-rsyslog.conf. No two rules must use the same queue file. Also, for
-obvious reasons, it must only contain those characters that can be used
-inside a valid file name. Rsyslog possibly adds some characters in front
-and/or at the end of that name when it creates files. So that name
-should not be at the file size name length limit (which should not be a
-problem these days).
+    action(
+        type="omfwd"
+        target="server"
+        port="port"                     # optional
+        protocol="tcp"
+        action.resumeRetryCount="-1"     # infinite retries on insert failure
+        queue.type="LinkedList"          # use asynchronous processing
+        queue.filename="srvrfwd"         # enables disk assistance
+        queue.saveOnShutdown="on"        # persist data if rsyslog shuts down
+    )
+
+The port given above is optional. It may be omitted, in which case you
+only provide the server name. The ``queue.filename`` is used to create
+disk-assisted queue files, should need arise. This value must be unique
+inside the configuration. No two actions must use the same queue file.
+Also, for obvious reasons, it must only contain those characters that
+can be used inside a valid file name. Rsyslog possibly adds some
+characters in front and/or at the end of that name when it creates
+files. So that name should not be at the file size name length limit
+(which should not be a problem these days). See
+:doc:`../rainerscript/queue_parameters` for the full list of queue
+options.
 
 Please note that actual spool files are only created if the remote
 server is down **and** there is no more space in the in-memory queue. By
@@ -114,36 +122,57 @@ your system.
 
 A sample for forwarding to two hosts looks like this:
 
-.. code-block:: linux-config
+.. code-block:: rsyslog
 
-    $ModLoad imuxsock # local message reception
-    $WorkDirectory /rsyslog/work # default location for work (spool) files
-    
+    module(load="imuxsock")
+    global(workDirectory="/rsyslog/work")
+
     # start forwarding rule 1
-    $ActionQueueType LinkedList # use asynchronous processing
-    $ActionQueueFileName srvrfwd1 # set file name, also enables disk mode
-    $ActionResumeRetryCount -1 # infinite retries on insert failure
-    $ActionQueueSaveOnShutdown on # save in-memory data if rsyslog shuts down
-    *.* @@server1:port
+    action(
+        type="omfwd"
+        target="server1"
+        port="port"
+        protocol="tcp"
+        action.resumeRetryCount="-1"
+        queue.type="LinkedList"
+        queue.filename="srvrfwd1"
+        queue.saveOnShutdown="on"
+    )
     # end forwarding rule 1
-    
+
     # start forwarding rule 2
-    $ActionQueueType LinkedList # use asynchronous processing
-    $ActionQueueFileName srvrfwd2 # set file name, also enables disk mode
-    $ActionResumeRetryCount -1 # infinite retries on insert failure
-    $ActionQueueSaveOnShutdown on # save in-memory data if rsyslog shuts down
-    *.* @@server2
+    action(
+        type="omfwd"
+        target="server2"
+        protocol="tcp"
+        action.resumeRetryCount="-1"
+        queue.type="LinkedList"
+        queue.filename="srvrfwd2"
+        queue.saveOnShutdown="on"
+    )
     # end forwarding rule 2
 
-Note the filename used for the first rule it is "srvrfwd1" and for the
-second it is "srvrfwd2". I have used a server without port name in the
+Note the filename used for the first rule it is ``srvrfwd1`` and for the
+second it is ``srvrfwd2``. I have used a server without port name in the
 second forwarding rule. This was just to illustrate how this can be
-done. You can also specify a port there (or drop the port from server1).
+done. You can also specify a port there (or drop the port from
+``server1``).
 
 When there are multiple action queues, they all work independently.
 Thus, if server1 goes down, server2 still receives data in real-time.
 The client will **not** block and wait for server1 to come back online.
 Similarly, server1's operation will not be affected by server2's state.
+
+See Also
+--------
+
+- :doc:`high_database_rate` for a more in-depth discussion of tuning
+  disk-assisted queues when writing to slow destinations such as
+  databases.
+- :doc:`failover_syslog_server` for a pattern that combines reliable
+  forwarding with multiple fallback targets.
+- :doc:`../concepts/queues` for a conceptual overview of the queueing
+  subsystem that underpins these configurations.
 
 Some Final Words on Reliability ...
 -----------------------------------


### PR DESCRIPTION
## Summary
- replace legacy configuration directives with Rainerscript module() and action() examples in the reliable forwarding and database tutorials, add contextual cross-references, and show how to build list-based SQL templates with the property replacer
- rework the log rotation tutorial to use rotation.sizeLimit parameters instead of $outchannel and link to the omfile reference
- modernize the priority-recording tutorial with Rainerscript list templates/actions and pointers to the template and prifilt documentation

## Testing
- make -C doc html *(fails: `sphinx-build: not found` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e29b70ebfc8332b67574929362fc9a