### PR TITLE
doc: make sphinx_rtd_theme the default HTML theme

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -103,6 +103,14 @@ We provide simple scripts that create a virtual environment (if missing), instal
     -   `powershell -ExecutionPolicy Bypass -File .\doc\tools\build-doc-windows.ps1 -Clean -Format html`
     -   Options: `-Strict`, `-Format html|epub`, `-Extra "<opts>"`.
 
+The default HTML theme is [`sphinx_rtd_theme`](https://sphinx-rtd-theme.readthedocs.io/). You can override it for any build by
+setting the `RSYSLOG_SPHINX_HTML_THEME` environment variable or by passing a Sphinx override, for example:
+
+-   `RSYSLOG_SPHINX_HTML_THEME=furo make -C doc html`
+-   `make -C doc html SPHINXOPTS="-D html_theme=furo"`
+
+Command-line `-D` overrides take precedence, allowing per-build theme selection without editing `conf.py`.
+
 ### Assumptions
 
 -   You want to install the `pip` Python package as a standard user, which places

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,6 @@
 
 # Align with conf.py needs_sphinx requirement
 sphinx>=4.5.0
+sphinx-rtd-theme
 furo
 sphinxcontrib.mermaid

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -238,7 +238,13 @@ html_baseurl = f'{RSYSLOG_BASE_URL}/doc/'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'furo'
+# Allow overriding the default theme via the environment. Passing
+# ``-D html_theme=<theme>`` still works because Sphinx applies command
+# line overrides after loading this file. If no override is provided we
+# fall back to the RTD theme for a consistent default experience.
+_env_html_theme = os.environ.get('RSYSLOG_SPHINX_HTML_THEME') \
+    or os.environ.get('SPHINX_HTML_THEME')
+html_theme = _env_html_theme or 'sphinx_rtd_theme'
 #html_theme = 'default'
 #html_theme = 'basic'
 #html_style = 'rsyslog.css'


### PR DESCRIPTION
## Summary
- set the documentation HTML theme default to ``sphinx_rtd_theme`` with an environment override
- document how to pick alternate themes from the command line
- add ``sphinx-rtd-theme`` to the documentation requirements list

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e36f25b56c8332847bf288c4419287