### PR TITLE
Fix tcpflood crash detection during RELP TLS tests

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1991,20 +1991,27 @@ tcpflood() {
 	else
 		check_only="no"
 	fi
-	eval ./tcpflood -p$TCPFLOOD_PORT "$@" $TCPFLOOD_EXTRA_OPTS
-	res=$?
-	if [ "$check_only" == "yes" ]; then
-		if [ "$res" -ne "0" ]; then
-			echo "error during tcpflood on port ${TCPFLOOD_PORT}! But test continues..."
-		fi
-		return 0
-	else
-		if [ "$res" -ne "0" ]; then
-			echo "error during tcpflood on port ${TCPFLOOD_PORT}! see ${RSYSLOG_OUT_LOG}.save for what was written"
-			cp ${RSYSLOG_OUT_LOG} ${RSYSLOG_OUT_LOG}.save
-			error_exit 1 stacktrace
-		fi
-	fi
+        eval ./tcpflood -p$TCPFLOOD_PORT "$@" $TCPFLOOD_EXTRA_OPTS
+        res=$?
+        if [ "$res" -ne "0" ]; then
+                if [ "$res" -ge 128 ]; then
+                        sig=$(( res - 128 ))
+                        echo "tcpflood terminated by signal ${sig} on port ${TCPFLOOD_PORT}!"
+                        if [ -f "${RSYSLOG_OUT_LOG}" ]; then
+                                cp "${RSYSLOG_OUT_LOG}" "${RSYSLOG_OUT_LOG}.save"
+                        fi
+                        error_exit 1 stacktrace
+                fi
+                if [ "$check_only" == "yes" ]; then
+                        echo "error during tcpflood on port ${TCPFLOOD_PORT}! But test continues..."
+                        return 0
+                fi
+                echo "error during tcpflood on port ${TCPFLOOD_PORT}! see ${RSYSLOG_OUT_LOG}.save for what was written"
+                if [ -f "${RSYSLOG_OUT_LOG}" ]; then
+                        cp "${RSYSLOG_OUT_LOG}" "${RSYSLOG_OUT_LOG}.save"
+                fi
+                error_exit 1 stacktrace
+        fi
 }
 
 

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -460,12 +460,13 @@ int openConn(const int connIdx) {
             }
     #endif
         }
-        relpCltArray[connIdx] = relpClt;
-        relp_r = relpCltConnect(relpCltArray[connIdx], 2, (unsigned char *)relpPort, (unsigned char *)targetIP);
+        relp_r = relpCltConnect(relpClt, 2, (unsigned char *)relpPort, (unsigned char *)targetIP);
         if (relp_r != RELP_RET_OK) {
             fprintf(stderr, "relp connect failed with return %d\n", relp_r);
+            relpEngineCltDestruct(pRelpEngine, &relpClt);
             return (1);
         }
+        relpCltArray[connIdx] = relpClt;
         sockArray[connIdx] = 1; /* mimic "all ok" state TODO: this looks invalid! */
 #endif
     } else { /* TCP, with or without TLS */
@@ -508,6 +509,8 @@ int openConn(const int connIdx) {
 static int progressCounter = 0;
 static pthread_mutex_t counterLock = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t reportedConnOpenErrLock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t connectionOpenFailedLock = PTHREAD_MUTEX_INITIALIZER;
+static int connectionOpenFailed = 0;
 typedef struct {
     int startIdx;
     int endIdx;
@@ -526,6 +529,9 @@ void *connectionWorker(void *arg) {
                 fprintf(stderr, "Error opening connection %d; %s\n", i, strerror(errno));
             }
             pthread_mutex_unlock(&reportedConnOpenErrLock);
+            pthread_mutex_lock(&connectionOpenFailedLock);
+            connectionOpenFailed = 1;
+            pthread_mutex_unlock(&connectionOpenFailedLock);
             pthread_exit(NULL);
         }
 
@@ -586,6 +592,10 @@ int openConnections(void) {
     int remainder = numConnections % threadCount;
     int startIdx = 0;
 
+    pthread_mutex_lock(&connectionOpenFailedLock);
+    connectionOpenFailed = 0;
+    pthread_mutex_unlock(&connectionOpenFailedLock);
+
     for (i = 0; i < threadCount; i++) {
         int endIdx = startIdx + connectionsPerThread - 1;
         endIdx += remainder;
@@ -605,6 +615,13 @@ int openConnections(void) {
     /* Wait for all connection open threads to finish */
     for (i = 0; i < threadCount; i++) {
         pthread_join(threads[i], NULL);
+    }
+
+    pthread_mutex_lock(&connectionOpenFailedLock);
+    const int failed = connectionOpenFailed;
+    pthread_mutex_unlock(&connectionOpenFailedLock);
+    if (failed) {
+        return 1;
     }
 
     return 0;


### PR DESCRIPTION
## Summary
- treat tcpflood signal exits as fatal even in --check-only mode so tests fail when the generator crashes without leaving a core file
- ensure tcpflood aborts cleanly after RELP connection setup failures by cleaning up the client handle and propagating the error across worker threads

## Testing
- make -C tests tcpflood
- ./tests/imrelp-tls-cfgcmd.sh *(fails: imrelp/imdiag plugins not built in this configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6905f1c160608332b12889717631addb