### PR TITLE
pmrfc3164: accept IPv6 literals as HOSTNAME tokens

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -95,6 +95,7 @@ TESTS_DEFAULT = \
 	prop-programname-with-slashes.sh \
 	hostname-with-slash-pmrfc5424.sh \
 	hostname-with-slash-pmrfc3164.sh \
+	pmrfc3164-ipv6-hostname.sh \
 	hostname-with-slash-dflt-invld.sh \
 	func-substring-invld-startpos.sh \
 	func-substring-large-endpos.sh \
@@ -2733,34 +2734,60 @@ test_files = testbench.h runtime-dummy.c
 DISTCLEANFILES=rsyslog.pid
 
 distclean-local:
+
 	rm -rf .dep_cache .dep_wrk
 
 
 
 EXTRA_DIST += \
+
 	faketime_common.sh \
+
 	privdrop_common.sh \
+
 	rscript_compare-common.sh \
+
 	rscript_parse_time_get-ts.py \
+
 	queue-persist-drvr.sh \
+
 	daqueue-persist-drvr.sh \
+
 	snmptrapreceiverv2.py \
+
 	validate_json_shell.sh \
+
 	tls-check-for-certificate.sh \
+
 	set-envvars.in \
+
 	urlencode.py \
+
 	dns_srv_mock.py \
+
 	omrelp-keepalive.sh \
+
 	improg-simul.sh \
+
 	sndrcv_drvr.sh \
+
 	sndrcv_drvr_noexit.sh \
+
 	diag.sh \
+
 	testsuites/mmexternal-SegFault-mm-python.py \
+
 	testsuites/mmsnareparse/sample-custom-pattern.data \
+
 	testsuites/mmsnareparse/sample-windows2022-security.data \
+
 	testsuites/mmsnareparse/sample-windows2025-security.data \
+
 	testsuites/mmsnareparse/sample-events.data \
+
 	1.rstest 2.rstest 3.rstest err1.rstest \
+
+
 	testsuites/include-std1-omfile-action.conf \
 	testsuites/include-std2-omfile-action.conf \
 	tls-certs/ca-key.pem \

--- a/tests/pmrfc3164-ipv6-hostname.sh
+++ b/tests/pmrfc3164-ipv6-hostname.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+## Test RFC3164 parser accepts IPv6 literals as HOSTNAME.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="customparser")
+parser(name="custom.rfc3164" type="pmrfc3164" permit.squarebracketsinhostname="on")
+template(name="outfmt" type="string" string="%hostname%\n")
+
+ruleset(name="customparser" parser="custom.rfc3164") {
+	action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+}
+'
+startup
+tcpflood -m1 -M "\"<129>Mar 10 01:00:00 2001:db8::1 tag: msgnum:1\""
+tcpflood -m1 -M "\"<129>Mar 10 01:00:00 [2001:db8::2] tag: msgnum:2\""
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='2001:db8::1
+[2001:db8::2]'
+cmp_exact
+
+exit_test


### PR DESCRIPTION
### Motivation
- The RFC3164 parser rejected IPv6 address literals in the HOSTNAME field, causing hostname parsing to fail and corrupt forwarded headers when sources send IPv6 addresses without DNS names. 
- The change aims to accept valid IPv6 literals (with optional square brackets) so TAG parsing stays aligned and forwarded messages keep correct syslog formatting.

### Description
- Added `#include <arpa/inet.h>` and a helper `isIPv6HostnameToken` that validates a candidate token as an IPv6 address using `inet_pton` and honors the `permit.squarebracketsinhostname` option. 
- Extended the hostname-parsing path in `tools/pmrfc3164.c` to, on normal-hostname rejection, scan the next token up to the next space and, if it contains a colon, validate and accept it as an IPv6 HOSTNAME token and advance the parse pointer accordingly. 
- Kept existing behavior for bracketed hostnames and plain hostnames, and preserved maximum hostname bounds (`CONF_HOSTNAME_MAXSIZE`).

### Testing
- Ran code formatting using `./devtools/format-code.sh`, which completed successfully. 
- No automated parser or runtime tests were executed as part of this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968b13ba2808332b9f4e0af6db79462)