### PR TITLE
Fix timezone refresh issue (issue #424)

### DIFF
--- a/contrib/imtuxedoulog/imtuxedoulog.c
+++ b/contrib/imtuxedoulog/imtuxedoulog.c
@@ -102,8 +102,7 @@ MODULE_CNFNAME("imtuxedoulog")
 
 /* Module static data */
 DEF_IMOD_STATIC_DATA /* must be present, starts static data */
-    DEFobjCurrIf(glbl) DEFobjCurrIf(strm) DEFobjCurrIf(prop) DEFobjCurrIf(ruleset)
-    DEFobjCurrIf(datetime)
+    DEFobjCurrIf(glbl) DEFobjCurrIf(strm) DEFobjCurrIf(prop) DEFobjCurrIf(ruleset) DEFobjCurrIf(datetime)
 
 #define NUM_MULTISUB 1024 /* default max number of submits */
 #define DFLT_PollInterval 10

--- a/contrib/imtuxedoulog/imtuxedoulog.c
+++ b/contrib/imtuxedoulog/imtuxedoulog.c
@@ -60,6 +60,7 @@
 #include "stringbuf.h"
 #include "ruleset.h"
 #include "ratelimit.h"
+#include "datetime.h"
 
 struct instanceConf_s {
     uchar *pszUlogBaseName;
@@ -102,6 +103,7 @@ MODULE_CNFNAME("imtuxedoulog")
 /* Module static data */
 DEF_IMOD_STATIC_DATA /* must be present, starts static data */
     DEFobjCurrIf(glbl) DEFobjCurrIf(strm) DEFobjCurrIf(prop) DEFobjCurrIf(ruleset)
+    DEFobjCurrIf(datetime)
 
 #define NUM_MULTISUB 1024 /* default max number of submits */
 #define DFLT_PollInterval 10
@@ -137,7 +139,7 @@ static uchar *mkFileNameWithTime(instanceConf_t *in) {
 #else
     gettimeofday(&tp, NULL);
 #endif
-    localtime_r(&tp.tv_sec, &(in->currTm));
+    datetime.sys_localtime_r(&tp.tv_sec, &(in->currTm));
     snprintf((char *)out, MAXFNAME, "%s.%02d%02d%02d", (char *)in->pszUlogBaseName, in->currTm.tm_mon + 1,
              in->currTm.tm_mday, in->currTm.tm_year % 100);
     return ustrdup(out);
@@ -768,6 +770,7 @@ BEGINmodExit
     objRelease(glbl, CORE_COMPONENT);
     objRelease(prop, CORE_COMPONENT);
     objRelease(ruleset, CORE_COMPONENT);
+    objRelease(datetime, CORE_COMPONENT);
 ENDmodExit
 
 BEGINqueryEtryPt
@@ -792,4 +795,5 @@ BEGINmodInit()
     CHKiRet(objUse(strm, CORE_COMPONENT));
     CHKiRet(objUse(ruleset, CORE_COMPONENT));
     CHKiRet(objUse(prop, CORE_COMPONENT));
+    CHKiRet(objUse(datetime, CORE_COMPONENT));
 ENDmodInit

--- a/plugins/impstats/impstats.c
+++ b/plugins/impstats/impstats.c
@@ -72,8 +72,7 @@ MODULE_CNFNAME("impstats")
 
 /* Module static data */
 DEF_IMOD_STATIC_DATA;
-DEFobjCurrIf(glbl) DEFobjCurrIf(prop) DEFobjCurrIf(statsobj) DEFobjCurrIf(ruleset)
-    DEFobjCurrIf(datetime)
+DEFobjCurrIf(glbl) DEFobjCurrIf(prop) DEFobjCurrIf(statsobj) DEFobjCurrIf(ruleset) DEFobjCurrIf(datetime)
 
     typedef struct configSettings_s {
     int iStatsInterval;

--- a/plugins/impstats/impstats.c
+++ b/plugins/impstats/impstats.c
@@ -51,6 +51,7 @@
 #include "prop.h"
 #include "ruleset.h"
 #include "parserif.h"
+#include "datetime.h"
 #include <libfastjson/json.h> /* libfastjson for robust JSON parsing in Zabbix collector */
 
 #ifdef ENABLE_IMPSTATS_PUSH
@@ -72,6 +73,7 @@ MODULE_CNFNAME("impstats")
 /* Module static data */
 DEF_IMOD_STATIC_DATA;
 DEFobjCurrIf(glbl) DEFobjCurrIf(prop) DEFobjCurrIf(statsobj) DEFobjCurrIf(ruleset)
+    DEFobjCurrIf(datetime)
 
     typedef struct configSettings_s {
     int iStatsInterval;
@@ -167,6 +169,7 @@ BEGINmodExit
     objRelease(prop, CORE_COMPONENT);
     objRelease(statsobj, CORE_COMPONENT);
     objRelease(ruleset, CORE_COMPONENT);
+    objRelease(datetime, CORE_COMPONENT);
 ENDmodExit
 BEGINisCompatibleWithFeature
     CODESTARTisCompatibleWithFeature;
@@ -1095,7 +1098,7 @@ static void generateZabbixStats(void) {
     char timebuf[32];
 #if defined(OS_LINUX) || defined(_POSIX_VERSION)
     struct tm tm_local;
-    localtime_r(&t, &tm_local);
+    datetime.sys_localtime_r(&t, &tm_local);
     strftime(timebuf, sizeof(timebuf), "%a %b %d %H:%M:%S %Y", &tm_local);
 #else
     strftime(timebuf, sizeof(timebuf), "%a %b %d %H:%M:%S %Y", localtime(&t));

--- a/runtime/datetime.h
+++ b/runtime/datetime.h
@@ -22,6 +22,7 @@
 #define INCLUDED_DATETIME_H
 
 #include <time.h>
+#include "obj-types.h"
 
 /* TODO: define error codes */
 #define NO_ERRCODE -1

--- a/runtime/datetime.h
+++ b/runtime/datetime.h
@@ -21,6 +21,8 @@
 #ifndef INCLUDED_DATETIME_H
 #define INCLUDED_DATETIME_H
 
+#include <time.h>
+
 /* TODO: define error codes */
 #define NO_ERRCODE -1
 
@@ -56,8 +58,11 @@ BEGINinterface(datetime) /* name must also be changed in ENDinterface macro! */
     time_t (*syslogTime2time_t)(const struct syslogTime *ts);
     /* v11, 2017-10-05 */
     int (*formatUnixTimeFromTime_t)(time_t time, const char *format, char *pBuf, uint pBufMax);
+    /* v12 - 2025-05-23: Add updateTimezone and sys_localtime_r */
+    void (*updateTimezone)(void);
+    struct tm *(*sys_localtime_r)(const time_t *timep, struct tm *result);
 ENDinterface(datetime)
-#define datetimeCURR_IF_VERSION 11 /* increment whenever you change the interface structure! */
+#define datetimeCURR_IF_VERSION 12 /* increment whenever you change the interface structure! */
     /* interface changes:
      * 1 - initial version
      * 2 - not compatible to 1 - bugfix required ParseTIMESTAMP3164 to accept char ** as
@@ -72,6 +77,7 @@ ENDinterface(datetime)
      * 10 - functions having addtl paramater inUTC to emit time in UTC:
      *      timeval2syslogTime, getCurrtime
      * 11 - Add formatUnixTimeFromTime_t
+     * 12 - Add updateTimezone and sys_localtime_r
      */
 
 #define PARSE3164_TZSTRING 1

--- a/runtime/nsd_mbedtls.c
+++ b/runtime/nsd_mbedtls.c
@@ -51,7 +51,7 @@ MODULE_TYPE_LIB
 MODULE_TYPE_KEEP
 
 /* static data */
-DEFobjStaticHelpers DEFobjCurrIf(glbl) DEFobjCurrIf(net) DEFobjCurrIf(nsd_ptcp)
+DEFobjStaticHelpers DEFobjCurrIf(glbl) DEFobjCurrIf(net) DEFobjCurrIf(nsd_ptcp) DEFobjCurrIf(datetime)
 /* Mbed TLS debug level (0..5)
  * 5 is the most logs.
  */
@@ -159,7 +159,7 @@ static rsRetVal get_custom_string(char **out) {
     struct tm tm;
 
     CHKiRet(gettimeofday(&tv, NULL));
-    if (localtime_r(&(tv.tv_sec), &tm) == NULL) {
+    if (datetime.sys_localtime_r(&(tv.tv_sec), &tm) == NULL) {
         ABORT_FINALIZE(RS_RET_NO_ERRCODE);
     }
     if (asprintf(out, "nsd_mbedtls-%04d-%02d-%02d %02d:%02d:%02d:%08ld", tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
@@ -1393,6 +1393,7 @@ BEGINObjClassExit(nsd_mbedtls, OBJ_IS_LOADABLE_MODULE) /* CHANGE class also in E
     objRelease(nsd_ptcp, LM_NSD_PTCP_FILENAME);
     objRelease(net, LM_NET_FILENAME);
     objRelease(glbl, CORE_COMPONENT);
+    objRelease(datetime, CORE_COMPONENT);
 ENDObjClassExit(nsd_mbedtls)
 
 /* Initialize the nsd_mbedtls class. Must be called as the very first method
@@ -1404,6 +1405,7 @@ BEGINObjClassInit(nsd_mbedtls, 1, OBJ_IS_LOADABLE_MODULE) /* class, version */
     CHKiRet(objUse(glbl, CORE_COMPONENT));
     CHKiRet(objUse(nsd_ptcp, LM_NSD_PTCP_FILENAME));
     CHKiRet(objUse(net, LM_NET_FILENAME));
+    CHKiRet(objUse(datetime, CORE_COMPONENT));
 
     /* now do global TLS init stuff */
     CHKiRet(mbedtlsGlblInit());

--- a/runtime/nsd_mbedtls.c
+++ b/runtime/nsd_mbedtls.c
@@ -46,6 +46,7 @@
 #include "nsd_mbedtls.h"
 #include "rsconf.h"
 #include "net.h"
+#include "datetime.h"
 
 MODULE_TYPE_LIB
 MODULE_TYPE_KEEP

--- a/runtime/operatingstate.c
+++ b/runtime/operatingstate.c
@@ -45,14 +45,13 @@
     #define lseek64(fd, offset, whence) lseek(fd, offset, whence)
 #endif
 
-DEFobjStaticHelpers
-DEFobjCurrIf(datetime)
+DEFobjStaticHelpers DEFobjCurrIf(datetime)
 
 /* some important standard states */
 #define STATE_INITIALIZING "INITIALIZING"
 #define STATE_CLEAN_CLOSE "CLEAN CLOSE"
 
-static int fd_osf = -1;
+    static int fd_osf = -1;
 
 /* check if old osf points to a problem and, if so, report */
 static void osf_checkOnStartup(void) {

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -2209,7 +2209,7 @@ static rsRetVal RateLimiter(qqueue_t *pThis) {
     if (pThis->iDeqtWinToHr != 25) { /* 25 means disabled */
         /* time calls are expensive, so only do them when needed */
         datetime.GetTime(&tCurr);
-        localtime_r(&tCurr, &m);
+        datetime.sys_localtime_r(&tCurr, &m);
         iHrCurr = m.tm_hour;
 
         if (pThis->iDeqtWinToHr < pThis->iDeqtWinFromHr) {

--- a/runtime/statsobj.c
+++ b/runtime/statsobj.c
@@ -71,10 +71,10 @@ int GatherStats = 0;
 DEFobjStaticHelpers;
 DEFobjCurrIf(datetime)
 
-/* doubly linked list of stats objects. Object is automatically linked to it
- * upon construction. Enqueue always happens at the front (simplifies logic).
- */
-static statsobj_t *objRoot = NULL;
+    /* doubly linked list of stats objects. Object is automatically linked to it
+     * upon construction. Enqueue always happens at the front (simplifies logic).
+     */
+    static statsobj_t *objRoot = NULL;
 static statsobj_t *objLast = NULL;
 
 static pthread_mutex_t mutStats;


### PR DESCRIPTION
Implement periodic timezone update using `tzset()` protected by a read-write lock.
Replace `localtime_r` calls with thread-safe `datetime.sys_localtime_r` wrapper.
This ensures rsyslog detects system timezone changes (e.g. `/etc/localtime`) without restart.
The check is performed every 5 minutes.

---
*PR created automatically by Jules for task [16606718362046625825](https://jules.google.com/task/16606718362046625825) started by @rgerhards*