### PR TITLE
🛡️ Sentinel: Fix excessive stack usage in JSON escaping

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-12 - Excessive Stack Allocation in Message Parsing
+**Vulnerability:** The function `jsonAddVal_escaped` in `runtime/msg.c` allocated a 100KB buffer on the stack (`uchar wrkbuf[100000]`), posing a risk of stack overflow (DoS) in constrained environments or deep call stacks.
+**Learning:** Legacy code optimization attempts (avoiding malloc) can sometimes introduce security risks like excessive stack usage if not bounded correctly.
+**Prevention:** Limit stack buffers to a reasonable size (e.g., 4KB) and implement fallbacks to heap allocation for larger data, as was already partially present but with an unsafe threshold.

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -3049,7 +3049,7 @@ static rsRetVal ATTR_NONNULL(1, 4) jsonAddVal_escaped(uchar *const pSrc,
     unsigned ni;
     unsigned char nc;
     int j;
-    uchar wrkbuf[100000];
+    uchar wrkbuf[4096];
     size_t dst_realloc_size;
     size_t dst_size;
     uchar *dst_base;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -156,6 +156,7 @@ TESTS_DEFAULT = \
 	privdropabortonidfaillegacy.sh \
 	json-nonstring.sh \
 	json-onempty-at-end.sh \
+	json-long-string.sh \
 	template-json.sh \
         template-pure-json.sh \
         template-jsonf-nested.sh \

--- a/tests/json-long-string.sh
+++ b/tests/json-long-string.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# This test checks if JSON escaping works for strings longer than the 4KB stack buffer.
+# It forces the code path that switches from stack to heap allocation in msg.c
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+# Create a long string with backslashes to force escaping
+set $!long = "a\\b\"c";
+# concatenate to make it long (approx 8KB)
+# 5 chars initial.
+# 10 iterations of doubling -> 5 * 1024 = 5120 bytes.
+set $!long = $!long & $!long; # 10
+set $!long = $!long & $!long; # 20
+set $!long = $!long & $!long; # 40
+set $!long = $!long & $!long; # 80
+set $!long = $!long & $!long; # 160
+set $!long = $!long & $!long; # 320
+set $!long = $!long & $!long; # 640
+set $!long = $!long & $!long; # 1280
+set $!long = $!long & $!long; # 2560
+set $!long = $!long & $!long; # 5120 - larger than 4096
+
+template(name="json" type="list" option.json="on") {
+        property(name="$!long")
+        constant(value="\n")
+}
+
+:msg, contains, "msgnum:" action(type="omfile" template="json"
+			         file=`echo $RSYSLOG_OUT_LOG`)
+'
+startup
+injectmsg 0 1
+shutdown_when_empty
+wait_shutdown
+
+if [ ! -f $RSYSLOG_OUT_LOG ]; then
+    error_exit 1
+fi
+
+# Check if output is not empty
+if [ ! -s $RSYSLOG_OUT_LOG ]; then
+    echo "Output file is empty"
+    error_exit 1
+fi
+
+# 5120 chars. Each needs escaping?
+# "a\b"c" -> "a\\b\"c" (7 chars)
+# 5120 * 7/5 = 7168 chars.
+# plus quotes.
+size=$(wc -c < $RSYSLOG_OUT_LOG)
+echo "Output size: $size"
+if [ $size -lt 6000 ]; then
+    echo "Output size too small"
+    error_exit 1
+fi
+
+exit_test


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix excessive stack usage in JSON escaping

🚨 Severity: MEDIUM
💡 Vulnerability: `jsonAddVal_escaped` allocated 100KB on the stack, posing a DoS risk via stack overflow.
🎯 Impact: Crash/Denial of Service in deep call stacks or constrained environments.
🔧 Fix: Reduced stack buffer to 4KB; existing malloc fallback handles larger data.
✅ Verification: New regression test `tests/json-long-string.sh` confirms large strings are still processed correctly.

---
*PR created automatically by Jules for task [3361815841138830520](https://jules.google.com/task/3361815841138830520) started by @rgerhards*