### PR TITLE
Fix undefined behavior in dnscache.c resolveAddr

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -1053,7 +1053,7 @@ static rsRetVal ATTR_NONNULL(1, 2) processDataRcvd(ptcpsess_t *const __restrict_
     }
 
     if (pThis->inputState == eAtStrtFram) {
-        if (pThis->bSuppOctetFram && isdigit((int)c)) {
+        if (pThis->bSuppOctetFram && isdigit((unsigned char)c)) {
             pThis->inputState = eInOctetCnt;
             pThis->iOctetsRemain = 0;
             pThis->eFraming = TCP_FRAMING_OCTET_COUNTING;
@@ -1075,7 +1075,7 @@ static rsRetVal ATTR_NONNULL(1, 2) processDataRcvd(ptcpsess_t *const __restrict_
         int lenPeerName = 0;
         uchar *propPeerIP = NULL;
         int lenPeerIP = 0;
-        if (isdigit(c)) {
+        if (isdigit((unsigned char)c)) {
             if (pThis->iOctetsRemain <= 200000000) {
                 pThis->iOctetsRemain = pThis->iOctetsRemain * 10 + c - '0';
             }

--- a/runtime/dnscache.c
+++ b/runtime/dnscache.c
@@ -310,7 +310,7 @@ static rsRetVal ATTR_NONNULL() resolveAddr(struct sockaddr_storage *addr, dnscac
             } else { /* we have a valid entry, so let's create the respective properties */
                 fqdnLen = strlen(fqdnBuf);
                 prop.CreateStringProp(&etry->fqdn, (uchar *)fqdnBuf, fqdnLen);
-                for (i = 0; i < fqdnLen; ++i) fqdnBuf[i] = tolower(fqdnBuf[i]);
+                for (i = 0; i < fqdnLen; ++i) fqdnBuf[i] = tolower((unsigned char)fqdnBuf[i]);
                 prop.CreateStringProp(&etry->fqdnLowerCase, (uchar *)fqdnBuf, fqdnLen);
             }
         }

--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -1544,7 +1544,7 @@ BEGINnewActInst
 
     int allWhiteSpace = 1;
     for (const char *p = (const char *)pData->fname; *p; ++p) {
-        if (!isspace(*p)) {
+        if (!isspace((unsigned char)*p)) {
             allWhiteSpace = 0;
             break;
         }


### PR DESCRIPTION
Fixed undefined behavior in `runtime/dnscache.c` where `tolower()` was called with a signed `char`, potentially leading to UB with negative values. Cast the argument to `unsigned char`.

---
*PR created automatically by Jules for task [16300544792167519701](https://jules.google.com/task/16300544792167519701) started by @rgerhards*