### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix IPv6 address handling in nsd_ptcp logging

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Journal
+
+## 2025-10-26 - IPv6 Support in Plain TCP Driver
+**Vulnerability:** The `nsd_ptcp` (Plain TCP) driver's `get_socket_info` function incorrectly assumes `AF_INET` (IPv4) for all connections, using `struct sockaddr_in` and `inet_ntop(AF_INET, ...)`.
+**Learning:** This results in incorrect or garbage IP addresses being logged for IPv6 connections, potentially misleading administrators during debugging or security incidents (e.g., failed connection attempts from IPv6 sources).
+**Prevention:** Always use `struct sockaddr_storage` for address storage and check `ss_family` (or `sa_family`) before casting to `sockaddr_in` or `sockaddr_in6`. Use `INET6_ADDRSTRLEN` for IP string buffers.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,6 +1,0 @@
-# Sentinel's Journal
-
-## 2025-10-26 - IPv6 Support in Plain TCP Driver
-**Vulnerability:** The `nsd_ptcp` (Plain TCP) driver's `get_socket_info` function incorrectly assumes `AF_INET` (IPv4) for all connections, using `struct sockaddr_in` and `inet_ntop(AF_INET, ...)`.
-**Learning:** This results in incorrect or garbage IP addresses being logged for IPv6 connections, potentially misleading administrators during debugging or security incidents (e.g., failed connection attempts from IPv6 sources).
-**Prevention:** Always use `struct sockaddr_storage` for address storage and check `ss_family` (or `sa_family`) before casting to `sockaddr_in` or `sockaddr_in6`. Use `INET6_ADDRSTRLEN` for IP string buffers.

--- a/runtime/nsd_ptcp.c
+++ b/runtime/nsd_ptcp.c
@@ -448,38 +448,58 @@ finalize_it:
 
 /* obtain connection info as soon as we are connected */
 static void get_socket_info(const int sockfd, char *const connInfo) {
-    char local_ip_str[INET_ADDRSTRLEN];  // Buffer to hold the IP address string
+    char local_ip_str[INET6_ADDRSTRLEN];  // Buffer to hold the IP address string
     int local_port = -1;
     char local_port_str[8];
-    char remote_ip_str[INET_ADDRSTRLEN];  // Buffer to hold the IP address string
+    char remote_ip_str[INET6_ADDRSTRLEN];  // Buffer to hold the IP address string
     int remote_port = -1;
     char remote_port_str[8];
-    struct sockaddr_in local_addr;
+    struct sockaddr_storage local_addr;
     socklen_t local_addr_len = sizeof(local_addr);
 
-    struct sockaddr_in remote_addr;
+    struct sockaddr_storage remote_addr;
     socklen_t remote_addr_len = sizeof(remote_addr);
 
     /* local system info */
-    local_addr.sin_port = 0; /* just to keep clang static analyzer happy */
     if (getsockname(sockfd, (struct sockaddr *)&local_addr, &local_addr_len) == -1) {
         strcpy(local_ip_str, "?");
     } else {
-        if (inet_ntop(AF_INET, &local_addr.sin_addr, local_ip_str, INET_ADDRSTRLEN) == NULL) {
+        if (local_addr.ss_family == AF_INET) {
+            struct sockaddr_in *sin = (struct sockaddr_in *)&local_addr;
+            if (inet_ntop(AF_INET, &sin->sin_addr, local_ip_str, sizeof(local_ip_str)) == NULL) {
+                strcpy(local_ip_str, "?");
+            }
+            local_port = ntohs(sin->sin_port);
+        } else if (local_addr.ss_family == AF_INET6) {
+            struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)&local_addr;
+            if (inet_ntop(AF_INET6, &sin6->sin6_addr, local_ip_str, sizeof(local_ip_str)) == NULL) {
+                strcpy(local_ip_str, "?");
+            }
+            local_port = ntohs(sin6->sin6_port);
+        } else {
             strcpy(local_ip_str, "?");
         }
-        local_port = ntohs(local_addr.sin_port);
     }
 
     /* remote system info */
-    remote_addr.sin_port = 0; /* just to keep clang static analyzer happy */
     if (getpeername(sockfd, (struct sockaddr *)&remote_addr, &remote_addr_len) == -1) {
         strcpy(remote_ip_str, "?");
     } else {
-        if (inet_ntop(AF_INET, &remote_addr.sin_addr, remote_ip_str, INET_ADDRSTRLEN) == NULL) {
+        if (remote_addr.ss_family == AF_INET) {
+            struct sockaddr_in *sin = (struct sockaddr_in *)&remote_addr;
+            if (inet_ntop(AF_INET, &sin->sin_addr, remote_ip_str, sizeof(remote_ip_str)) == NULL) {
+                strcpy(remote_ip_str, "?");
+            }
+            remote_port = ntohs(sin->sin_port);
+        } else if (remote_addr.ss_family == AF_INET6) {
+            struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)&remote_addr;
+            if (inet_ntop(AF_INET6, &sin6->sin6_addr, remote_ip_str, sizeof(remote_ip_str)) == NULL) {
+                strcpy(remote_ip_str, "?");
+            }
+            remote_port = ntohs(sin6->sin6_port);
+        } else {
             strcpy(remote_ip_str, "?");
         }
-        remote_port = ntohs(remote_addr.sin_port);
     }
 
     if (local_port == -1) {

--- a/runtime/nsd_ptcp.c
+++ b/runtime/nsd_ptcp.c
@@ -448,12 +448,13 @@ finalize_it:
 
 /* obtain connection info as soon as we are connected */
 static void get_socket_info(const int sockfd, char *const connInfo) {
-    char local_ip_str[INET6_ADDRSTRLEN];  // Buffer to hold the IP address string
+    char local_ip_str[INET6_ADDRSTRLEN + 3];  // Buffer to hold the IP address string, +3 for [], \0
     int local_port = -1;
     char local_port_str[8];
-    char remote_ip_str[INET6_ADDRSTRLEN];  // Buffer to hold the IP address string
+    char remote_ip_str[INET6_ADDRSTRLEN + 3];  // Buffer to hold the IP address string, +3 for [], \0
     int remote_port = -1;
     char remote_port_str[8];
+    char ip_buf[INET6_ADDRSTRLEN];
     struct sockaddr_storage local_addr;
     socklen_t local_addr_len = sizeof(local_addr);
 
@@ -462,54 +463,58 @@ static void get_socket_info(const int sockfd, char *const connInfo) {
 
     /* local system info */
     if (getsockname(sockfd, (struct sockaddr *)&local_addr, &local_addr_len) == -1) {
-        strcpy(local_ip_str, "?");
+        snprintf(local_ip_str, sizeof(local_ip_str), "?");
     } else {
         if (local_addr.ss_family == AF_INET) {
             struct sockaddr_in *sin = (struct sockaddr_in *)&local_addr;
             if (inet_ntop(AF_INET, &sin->sin_addr, local_ip_str, sizeof(local_ip_str)) == NULL) {
-                strcpy(local_ip_str, "?");
+                snprintf(local_ip_str, sizeof(local_ip_str), "?");
             }
             local_port = ntohs(sin->sin_port);
         } else if (local_addr.ss_family == AF_INET6) {
             struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)&local_addr;
-            if (inet_ntop(AF_INET6, &sin6->sin6_addr, local_ip_str, sizeof(local_ip_str)) == NULL) {
-                strcpy(local_ip_str, "?");
+            if (inet_ntop(AF_INET6, &sin6->sin6_addr, ip_buf, sizeof(ip_buf)) != NULL) {
+                snprintf(local_ip_str, sizeof(local_ip_str), "[%s]", ip_buf);
+            } else {
+                snprintf(local_ip_str, sizeof(local_ip_str), "?");
             }
             local_port = ntohs(sin6->sin6_port);
         } else {
-            strcpy(local_ip_str, "?");
+            snprintf(local_ip_str, sizeof(local_ip_str), "?");
         }
     }
 
     /* remote system info */
     if (getpeername(sockfd, (struct sockaddr *)&remote_addr, &remote_addr_len) == -1) {
-        strcpy(remote_ip_str, "?");
+        snprintf(remote_ip_str, sizeof(remote_ip_str), "?");
     } else {
         if (remote_addr.ss_family == AF_INET) {
             struct sockaddr_in *sin = (struct sockaddr_in *)&remote_addr;
             if (inet_ntop(AF_INET, &sin->sin_addr, remote_ip_str, sizeof(remote_ip_str)) == NULL) {
-                strcpy(remote_ip_str, "?");
+                snprintf(remote_ip_str, sizeof(remote_ip_str), "?");
             }
             remote_port = ntohs(sin->sin_port);
         } else if (remote_addr.ss_family == AF_INET6) {
             struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)&remote_addr;
-            if (inet_ntop(AF_INET6, &sin6->sin6_addr, remote_ip_str, sizeof(remote_ip_str)) == NULL) {
-                strcpy(remote_ip_str, "?");
+            if (inet_ntop(AF_INET6, &sin6->sin6_addr, ip_buf, sizeof(ip_buf)) != NULL) {
+                snprintf(remote_ip_str, sizeof(remote_ip_str), "[%s]", ip_buf);
+            } else {
+                snprintf(remote_ip_str, sizeof(remote_ip_str), "?");
             }
             remote_port = ntohs(sin6->sin6_port);
         } else {
-            strcpy(remote_ip_str, "?");
+            snprintf(remote_ip_str, sizeof(remote_ip_str), "?");
         }
     }
 
     if (local_port == -1) {
-        strcpy(local_port_str, "?");
+        snprintf(local_port_str, sizeof(local_port_str), "?");
     } else {
         snprintf(local_port_str, 7, "%d", local_port);
         local_port_str[7] = '\0'; /* be on safe side */
     }
     if (remote_port == -1) {
-        strcpy(remote_port_str, "?");
+        snprintf(remote_port_str, sizeof(remote_port_str), "?");
     } else {
         snprintf(remote_port_str, 7, "%d", remote_port);
         remote_port_str[7] = '\0'; /* be on safe side */

--- a/runtime/tcpsrv.h
+++ b/runtime/tcpsrv.h
@@ -198,7 +198,7 @@ struct tcpsrv_s {
         rsRetVal (*pOnErrClose)(tcps_sess_t *pSess);
         /* session specific callbacks */
         rsRetVal (*pOnSessAccept)(tcpsrv_t *, tcps_sess_t *, char *connInfo);
-#define TCPSRV_CONNINFO_SIZE (2 * (INET_ADDRSTRLEN + 20))
+#define TCPSRV_CONNINFO_SIZE (2 * (INET6_ADDRSTRLEN + 20))
         rsRetVal (*OnSessConstructFinalize)(void *);
         rsRetVal (*pOnSessDestruct)(void *);
         rsRetVal (*OnMsgReceive)(tcps_sess_t *, uchar *pszMsg, int iLenMsg); /* submit message callback */

--- a/runtime/tcpsrv.h
+++ b/runtime/tcpsrv.h
@@ -198,7 +198,7 @@ struct tcpsrv_s {
         rsRetVal (*pOnErrClose)(tcps_sess_t *pSess);
         /* session specific callbacks */
         rsRetVal (*pOnSessAccept)(tcpsrv_t *, tcps_sess_t *, char *connInfo);
-#define TCPSRV_CONNINFO_SIZE (2 * (INET6_ADDRSTRLEN + 20))
+#define TCPSRV_CONNINFO_SIZE 128
         rsRetVal (*OnSessConstructFinalize)(void *);
         rsRetVal (*pOnSessDestruct)(void *);
         rsRetVal (*OnMsgReceive)(tcps_sess_t *, uchar *pszMsg, int iLenMsg); /* submit message callback */


### PR DESCRIPTION
Sentinel 🛡️ Security Fix:
The `nsd_ptcp` driver was incorrectly logging IPv6 addresses by casting them to `sockaddr_in` and using `AF_INET`. This resulted in garbage data in debug logs and error messages. 

This PR fixes the issue by:
1.  Upgrading `TCPSRV_CONNINFO_SIZE` in `runtime/tcpsrv.h` to support the length of two IPv6 addresses + ports.
2.  Updating `runtime/nsd_ptcp.c` to correctly detect address family (`AF_INET` vs `AF_INET6`) and use `inet_ntop` with the correct parameters.

This ensures correct IP information is logged for both IPv4 and IPv6 connections.

---
*PR created automatically by Jules for task [14038852679306683894](https://jules.google.com/task/14038852679306683894) started by @rgerhards*