### PR TITLE
ci: add Debian 13 package build workflow

### DIFF
--- a/.github/debian-ci-policy.yml
+++ b/.github/debian-ci-policy.yml
@@ -1,19 +1,14 @@
 {
-  "allowed_patch_skips": [],
-  "supplemental_build_deps": [
+  "allowed_patch_skips": [
     {
-      "package": "protobuf-c-compiler",
-      "reason": "Needed by upstream build flow before Debian packaging catches up."
+      "patch": "Fix-doc-version-for-sphinx-build.patch",
+      "reason": "Debian latest still carries a doc-version patch that no longer applies to upstream doc/source/conf.py."
     },
     {
-      "package": "libprotobuf-c-dev",
-      "reason": "Needed by upstream build flow before Debian packaging catches up."
+      "patch": "imfile-preserve-symlink-cleanup-notifications-with-deferr.patch",
+      "reason": "Debian latest still carries an imfile patch that is already effectively upstream and now applies in reverse."
     }
   ],
-  "not_installed_paths": [
-    {
-      "path": "usr/lib/${DEB_HOST_MULTIARCH}/rsyslog/mmleefparse.so",
-      "reason": "Temporary Debian packaging compatibility workaround until packaging metadata is updated."
-    }
-  ]
+  "supplemental_build_deps": [],
+  "not_installed_paths": []
 }

--- a/.github/debian-ci-policy.yml
+++ b/.github/debian-ci-policy.yml
@@ -1,0 +1,19 @@
+{
+  "allowed_patch_skips": [],
+  "supplemental_build_deps": [
+    {
+      "package": "protobuf-c-compiler",
+      "reason": "Needed by upstream build flow before Debian packaging catches up."
+    },
+    {
+      "package": "libprotobuf-c-dev",
+      "reason": "Needed by upstream build flow before Debian packaging catches up."
+    }
+  ],
+  "not_installed_paths": [
+    {
+      "path": "usr/lib/${DEB_HOST_MULTIARCH}/rsyslog/mmleefparse.so",
+      "reason": "Temporary Debian packaging compatibility workaround until packaging metadata is updated."
+    }
+  ]
+}

--- a/.github/scripts/debian_package_build.sh
+++ b/.github/scripts/debian_package_build.sh
@@ -251,6 +251,7 @@ resolve_patch_policy() {
 
     local failed_patch
     local failed_patch_name
+    local excluded_key
     failed_patch="$(
       sed -n 's/^Applying patch \(.*\)$/\1/p' /tmp/quilt-push.log | tail -1
     )"
@@ -275,7 +276,8 @@ resolve_patch_policy() {
       return 1
     fi
 
-    if grep -Fxq "$failed_patch_name" "$excluded_file"; then
+    excluded_key="$failed_patch"
+    if grep -Fxq "$excluded_key" "$excluded_file"; then
       echo "ERROR: patch resolution loop detected at '$failed_patch_name'" >&2
       return 1
     fi
@@ -288,7 +290,7 @@ resolve_patch_policy() {
       END {if (!removed) exit 9}
     ' "$series_file" > "$series_file.new"
     mv "$series_file.new" "$series_file"
-    printf '%s\n' "$failed_patch_name" >> "$excluded_file"
+    printf '%s\n' "$excluded_key" >> "$excluded_file"
 
     if [ -n "$findings_dir" ]; then
       local reason

--- a/.github/scripts/debian_package_build.sh
+++ b/.github/scripts/debian_package_build.sh
@@ -250,6 +250,7 @@ resolve_patch_policy() {
     fi
 
     local failed_patch
+    local failed_patch_name
     failed_patch="$(
       sed -n 's/^Applying patch \(.*\)$/\1/p' /tmp/quilt-push.log | tail -1
     )"
@@ -257,45 +258,47 @@ resolve_patch_policy() {
       echo "ERROR: could not determine failing patch" >&2
       return 1
     fi
+    failed_patch_name="${failed_patch##*/}"
 
-    if ! grep -Fxq "$failed_patch" "$allowed_tmp"; then
+    if ! grep -Fxq "$failed_patch" "$allowed_tmp" && \
+       ! grep -Fxq "$failed_patch_name" "$allowed_tmp"; then
       if [ "$mode" = "diagnostics" ] && [ -n "$findings_dir" ]; then
         append_finding "$findings_dir" "blocking_gate_failures" \
-          "- Unexpected Debian patch failure: \`$failed_patch\` does not match the allowlist."
+          "- Unexpected Debian patch failure: \`$failed_patch_name\` does not match the allowlist."
         append_finding "$findings_dir" "release_handoff_items" \
-          "- Refresh or drop Debian patch \`$failed_patch\`; CI could not apply it against upstream."
+          "- Refresh or drop Debian patch \`$failed_patch_name\`; CI could not apply it against upstream."
         quilt pop -a >/dev/null 2>&1 || true
         return 0
       fi
 
-      echo "ERROR: unexpected Debian patch failure '$failed_patch'" >&2
+      echo "ERROR: unexpected Debian patch failure '$failed_patch_name'" >&2
       return 1
     fi
 
-    if grep -Fxq "$failed_patch" "$excluded_file"; then
-      echo "ERROR: patch resolution loop detected at '$failed_patch'" >&2
+    if grep -Fxq "$failed_patch_name" "$excluded_file"; then
+      echo "ERROR: patch resolution loop detected at '$failed_patch_name'" >&2
       return 1
     fi
 
-    awk -v p="$failed_patch" '
+    awk -v p="$failed_patch" -v pb="$failed_patch_name" '
       /^#/ {print; next}
       NF == 0 {print; next}
-      $1 == p {removed = 1; next}
+      $1 == p || $1 == pb {removed = 1; next}
       {print}
       END {if (!removed) exit 9}
     ' "$series_file" > "$series_file.new"
     mv "$series_file.new" "$series_file"
-    printf '%s\n' "$failed_patch" >> "$excluded_file"
+    printf '%s\n' "$failed_patch_name" >> "$excluded_file"
 
     if [ -n "$findings_dir" ]; then
       local reason
       reason="$(
-        awk -F '\t' -v p="$failed_patch" '$1 == p {print $2}' "$reasons_file"
+        awk -F '\t' -v p="$failed_patch" -v pb="$failed_patch_name" '$1 == p || $1 == pb {print $2}' "$reasons_file"
       )"
       append_finding "$findings_dir" "allowed_patch_drift" \
-        "- Skipped allowed Debian patch \`$failed_patch\`: ${reason:-No reason recorded.}"
+        "- Skipped allowed Debian patch \`$failed_patch_name\`: ${reason:-No reason recorded.}"
       append_finding "$findings_dir" "release_handoff_items" \
-        "- Refresh or drop Debian patch \`$failed_patch\`: ${reason:-No reason recorded.}"
+        "- Refresh or drop Debian patch \`$failed_patch_name\`: ${reason:-No reason recorded.}"
     fi
   done
 

--- a/.github/scripts/debian_package_build.sh
+++ b/.github/scripts/debian_package_build.sh
@@ -154,9 +154,9 @@ install_build_deps() {
       if ! apt-cache show "$pkg" >/dev/null 2>&1; then
         if [ -n "$findings_dir" ]; then
           append_finding "$findings_dir" "unavailable_dependencies" \
-            "- Policy-listed package \`$pkg\` is not available in Debian 13."
+            "- Policy-listed package \`$pkg\` is not available in the Debian experimental baseline environment."
         fi
-        echo "ERROR: policy-listed package '$pkg' is not available in Debian 13" >&2
+        echo "ERROR: policy-listed package '$pkg' is not available in the Debian experimental baseline environment" >&2
         return 1
       fi
     done < "$extra_deps_file"
@@ -352,7 +352,7 @@ blocking_gate_failures|Blocking gate failures
 allowed_patch_drift|Allowed Debian patch drift
 allowed_dependency_drift|Allowed Debian dependency drift
 allowed_packaging_drift|Allowed packaging drift
-unavailable_dependencies|Unavailable Debian 13 dependencies
+unavailable_dependencies|Unavailable Debian experimental baseline dependencies
 docs_test_observations|Debian docs/test observations
 release_handoff_items|Release handoff items
 EOF2

--- a/.github/scripts/debian_package_build.sh
+++ b/.github/scripts/debian_package_build.sh
@@ -1,0 +1,371 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+append_finding() {
+  local findings_dir="$1"
+  local section="$2"
+  local message="$3"
+
+  mkdir -p "$findings_dir"
+  printf '%s\n' "$message" >> "$findings_dir/$section.md"
+}
+
+load_policy() {
+  local policy_file="$1"
+  local out_dir="$2"
+
+  rm -rf "$out_dir"
+  mkdir -p "$out_dir"
+
+  python3 - "$policy_file" "$out_dir" <<'PY'
+import json
+import os
+import sys
+
+policy_path, out_dir = sys.argv[1], sys.argv[2]
+with open(policy_path, "r", encoding="utf-8") as fh:
+    policy = json.load(fh)
+
+sections = {
+    "allowed_patch_skips": ("patch", "reason"),
+    "supplemental_build_deps": ("package", "reason"),
+    "not_installed_paths": ("path", "reason"),
+}
+
+for key, (name_key, reason_key) in sections.items():
+    names_path = os.path.join(out_dir, f"{key}.txt")
+    reasons_path = os.path.join(out_dir, f"{key}.reasons.txt")
+    with open(names_path, "w", encoding="utf-8") as names_fh, \
+            open(reasons_path, "w", encoding="utf-8") as reasons_fh:
+        for entry in policy.get(key, []):
+            name = entry.get(name_key, "").strip()
+            reason = entry.get(reason_key, "").strip()
+            if not name:
+                continue
+            names_fh.write(f"{name}\n")
+            reasons_fh.write(f"{name}\t{reason}\n")
+PY
+}
+
+install_prereqs() {
+  apt-get update
+  apt-get install -y --no-install-recommends \
+    autoconf \
+    automake \
+    autotools-dev \
+    bison \
+    ca-certificates \
+    devscripts \
+    dpkg-dev \
+    equivs \
+    flex \
+    g++ \
+    git \
+    libtool \
+    make \
+    pkg-config \
+    python3 \
+    python3-docutils \
+    quilt
+}
+
+fetch_debian_packaging() {
+  local target_dir="$1"
+
+  rm -rf "$target_dir" /tmp/debian-rsyslog
+  git clone --depth=1 --branch debian/master \
+    https://salsa.debian.org/debian/rsyslog.git \
+    /tmp/debian-rsyslog
+
+  if [ ! -d /tmp/debian-rsyslog/debian ]; then
+    echo "ERROR: Could not obtain Debian packaging files" >&2
+    return 1
+  fi
+
+  cp -r /tmp/debian-rsyslog/debian "$target_dir"
+}
+
+run_dist_build() {
+  local workspace="$1"
+
+  cd "$workspace"
+  autoreconf -fvi
+  ./configure --enable-silent-rules --disable-testbench \
+     --disable-imdiag --disable-imdocker --disable-imfile \
+     --disable-default-tests --disable-impstats \
+     --disable-impstats-push --disable-imptcp \
+     --disable-mmanon --disable-mmaudit --disable-mmfields \
+     --disable-mmjsonparse --disable-mmpstrucdata \
+     --disable-mmsequence --disable-mmutf8fix --disable-mail \
+     --disable-omprog --disable-improg --disable-omruleset \
+     --disable-omstdout --disable-omuxsock \
+     --disable-pmaixforwardedfrom --disable-pmciscoios \
+     --disable-pmcisconames --disable-pmlastmsg --disable-pmsnare \
+     --disable-libgcrypt --disable-mmnormalize \
+     --disable-omudpspoof --disable-relp --disable-mmsnmptrapd \
+     --disable-gnutls --disable-usertools --disable-mysql \
+     --disable-valgrind --disable-omjournal --enable-libsystemd \
+     --disable-mmkubernetes --disable-imjournal \
+     --disable-omkafka --disable-imkafka --disable-ommongodb \
+     --disable-omrabbitmq --disable-journal-tests --disable-mmdarwin \
+     --disable-helgrind --disable-uuid --disable-fmhttp
+  make dist
+}
+
+find_dist_tarball() {
+  local workspace="$1"
+
+  cd "$workspace"
+
+  local dist_tarball
+  dist_tarball="$(ls -1 rsyslog-*.tar.gz | head -1)"
+  if [ -z "$dist_tarball" ]; then
+    echo "ERROR: make dist did not produce rsyslog-*.tar.gz" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$dist_tarball"
+}
+
+unpack_source_tree() {
+  local workspace="$1"
+  local dist_tarball="$2"
+  local packaging_dir="$3"
+  local source_dir="$4"
+
+  rm -rf "$source_dir"
+  mkdir -p "$source_dir"
+  tar -xf "$workspace/$dist_tarball" -C "$source_dir" --strip-components=1
+  cp -r "$packaging_dir" "$source_dir/debian"
+}
+
+install_build_deps() {
+  local control_file="$1"
+  local extra_deps_file="$2"
+  local findings_dir="${3:-}"
+
+  if [ -s "$extra_deps_file" ]; then
+    while IFS= read -r pkg; do
+      [ -n "$pkg" ] || continue
+      if ! apt-cache show "$pkg" >/dev/null 2>&1; then
+        if [ -n "$findings_dir" ]; then
+          append_finding "$findings_dir" "unavailable_dependencies" \
+            "- Policy-listed package \`$pkg\` is not available in Debian 13."
+        fi
+        echo "ERROR: policy-listed package '$pkg' is not available in Debian 13" >&2
+        return 1
+      fi
+    done < "$extra_deps_file"
+
+    xargs -r apt-get install -y --no-install-recommends < "$extra_deps_file"
+  fi
+
+  local apt_tool
+  apt_tool="apt-get -o Debug::pkgProblemResolver=yes"
+  apt_tool="$apt_tool --no-install-recommends --yes"
+  mk-build-deps --install --remove \
+    --tool="$apt_tool" \
+    "$control_file"
+}
+
+record_policy_items() {
+  local reasons_file="$1"
+  local findings_dir="$2"
+  local primary_section="$3"
+  local release_prefix="$4"
+
+  [ -s "$reasons_file" ] || return 0
+
+  while IFS=$'\t' read -r name reason; do
+    [ -n "$name" ] || continue
+    append_finding "$findings_dir" "$primary_section" \
+      "- \`$name\`: ${reason:-No reason recorded.}"
+    append_finding "$findings_dir" "release_handoff_items" \
+      "- $release_prefix \`$name\`: ${reason:-No reason recorded.}"
+  done < "$reasons_file"
+}
+
+apply_not_installed_policy() {
+  local source_dir="$1"
+  local not_installed_file="$2"
+  local reasons_file="$3"
+  local findings_dir="${4:-}"
+  local not_installed_path="$source_dir/debian/not-installed"
+
+  [ -s "$not_installed_file" ] || return 0
+
+  touch "$not_installed_path"
+  while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    if ! grep -Fqx "$entry" "$not_installed_path"; then
+      printf '%s\n' "$entry" >> "$not_installed_path"
+    fi
+  done < "$not_installed_file"
+
+  if [ -n "$findings_dir" ]; then
+    record_policy_items "$reasons_file" "$findings_dir" \
+      "allowed_packaging_drift" "Update Debian not-installed handling for"
+  fi
+}
+
+resolve_patch_policy() {
+  local source_dir="$1"
+  local allowed_file="$2"
+  local reasons_file="$3"
+  local mode="$4"
+  local findings_dir="${5:-}"
+  local allowed_tmp="/tmp/debian-ci-allowed-patches.txt"
+  local excluded_file="/tmp/excluded-debian-patches.txt"
+  local series_file="$source_dir/debian/patches/series"
+
+  : > "$excluded_file"
+  cp "$allowed_file" "$allowed_tmp" 2>/dev/null || : > "$allowed_tmp"
+
+  if [ ! -f "$series_file" ] || [ ! -s "$series_file" ]; then
+    return 0
+  fi
+
+  cd "$source_dir"
+  export QUILT_PATCHES=debian/patches
+
+  while true; do
+    quilt pop -a >/dev/null 2>&1 || true
+
+    set +e
+    quilt push -a > /tmp/quilt-push.log 2>&1
+    rc=$?
+    set -e
+    cat /tmp/quilt-push.log
+
+    if grep -q "No series file found" /tmp/quilt-push.log; then
+      break
+    fi
+
+    if [ "$rc" -eq 0 ]; then
+      break
+    fi
+
+    local failed_patch
+    failed_patch="$(
+      sed -n 's/^Applying patch \(.*\)$/\1/p' /tmp/quilt-push.log | tail -1
+    )"
+    if [ -z "$failed_patch" ]; then
+      echo "ERROR: could not determine failing patch" >&2
+      return 1
+    fi
+
+    if ! grep -Fxq "$failed_patch" "$allowed_tmp"; then
+      if [ "$mode" = "diagnostics" ] && [ -n "$findings_dir" ]; then
+        append_finding "$findings_dir" "blocking_gate_failures" \
+          "- Unexpected Debian patch failure: \`$failed_patch\` does not match the allowlist."
+        append_finding "$findings_dir" "release_handoff_items" \
+          "- Refresh or drop Debian patch \`$failed_patch\`; CI could not apply it against upstream."
+        quilt pop -a >/dev/null 2>&1 || true
+        return 0
+      fi
+
+      echo "ERROR: unexpected Debian patch failure '$failed_patch'" >&2
+      return 1
+    fi
+
+    if grep -Fxq "$failed_patch" "$excluded_file"; then
+      echo "ERROR: patch resolution loop detected at '$failed_patch'" >&2
+      return 1
+    fi
+
+    awk -v p="$failed_patch" '
+      /^#/ {print; next}
+      NF == 0 {print; next}
+      $1 == p {removed = 1; next}
+      {print}
+      END {if (!removed) exit 9}
+    ' "$series_file" > "$series_file.new"
+    mv "$series_file.new" "$series_file"
+    printf '%s\n' "$failed_patch" >> "$excluded_file"
+
+    if [ -n "$findings_dir" ]; then
+      local reason
+      reason="$(
+        awk -F '\t' -v p="$failed_patch" '$1 == p {print $2}' "$reasons_file"
+      )"
+      append_finding "$findings_dir" "allowed_patch_drift" \
+        "- Skipped allowed Debian patch \`$failed_patch\`: ${reason:-No reason recorded.}"
+      append_finding "$findings_dir" "release_handoff_items" \
+        "- Refresh or drop Debian patch \`$failed_patch\`: ${reason:-No reason recorded.}"
+    fi
+  done
+
+  quilt pop -a >/dev/null 2>&1 || true
+}
+
+build_package() {
+  local source_dir="$1"
+
+  cd "$source_dir"
+  export DEB_BUILD_OPTIONS="nocheck"
+  dpkg-buildpackage -b -uc -us -j"$(nproc)"
+}
+
+verify_docs() {
+  local source_dir="$1"
+
+  [ -d "$source_dir/debian/build" ] && \
+  [ -f "$source_dir/debian/build/index.html" ]
+}
+
+init_findings_dir() {
+  local findings_dir="$1"
+  rm -rf "$findings_dir"
+  mkdir -p "$findings_dir"
+}
+
+render_findings() {
+  local findings_dir="$1"
+  local output_file="$2"
+  local gate_result="${3:-unknown}"
+
+  cat > "$output_file" <<EOF
+Debian diagnostics findings
+==========================
+
+Required gate result: $gate_result
+EOF
+
+  local section title
+  while IFS='|' read -r section title; do
+    if [ -s "$findings_dir/$section.md" ]; then
+      printf '\n%s\n\n' "$title" >> "$output_file"
+      cat "$findings_dir/$section.md" >> "$output_file"
+    fi
+  done <<'EOF'
+blocking_gate_failures|Blocking gate failures
+allowed_patch_drift|Allowed Debian patch drift
+allowed_dependency_drift|Allowed Debian dependency drift
+allowed_packaging_drift|Allowed packaging drift
+unavailable_dependencies|Unavailable Debian 13 dependencies
+docs_test_observations|Debian docs/test observations
+release_handoff_items|Release handoff items
+EOF
+}
+
+case "${1:-}" in
+  append_finding) shift; append_finding "$@" ;;
+  load_policy) shift; load_policy "$@" ;;
+  install_prereqs) shift; install_prereqs "$@" ;;
+  fetch_debian_packaging) shift; fetch_debian_packaging "$@" ;;
+  run_dist_build) shift; run_dist_build "$@" ;;
+  find_dist_tarball) shift; find_dist_tarball "$@" ;;
+  unpack_source_tree) shift; unpack_source_tree "$@" ;;
+  install_build_deps) shift; install_build_deps "$@" ;;
+  record_policy_items) shift; record_policy_items "$@" ;;
+  apply_not_installed_policy) shift; apply_not_installed_policy "$@" ;;
+  resolve_patch_policy) shift; resolve_patch_policy "$@" ;;
+  build_package) shift; build_package "$@" ;;
+  verify_docs) shift; verify_docs "$@" ;;
+  init_findings_dir) shift; init_findings_dir "$@" ;;
+  render_findings) shift; render_findings "$@" ;;
+  *)
+    echo "Usage: $0 <command> [args...]" >&2
+    exit 2
+    ;;
+esac

--- a/.github/scripts/debian_package_build.sh
+++ b/.github/scripts/debian_package_build.sh
@@ -54,6 +54,7 @@ install_prereqs() {
     automake \
     autotools-dev \
     bison \
+    build-essential \
     ca-certificates \
     devscripts \
     dpkg-dev \
@@ -70,19 +71,22 @@ install_prereqs() {
 }
 
 fetch_debian_packaging() {
-  local target_dir="$1"
+  local repo_url="$1"
+  local branch="$2"
+  local target_dir="$3"
+  local clone_dir="/tmp/debian-packaging-clone"
 
-  rm -rf "$target_dir" /tmp/debian-rsyslog
-  git clone --depth=1 --branch debian/master \
-    https://salsa.debian.org/debian/rsyslog.git \
-    /tmp/debian-rsyslog
+  rm -rf "$target_dir" "$clone_dir"
+  git clone --depth=1 --branch "$branch" \
+    "$repo_url" \
+    "$clone_dir"
 
-  if [ ! -d /tmp/debian-rsyslog/debian ]; then
-    echo "ERROR: Could not obtain Debian packaging files" >&2
+  if [ ! -d "$clone_dir/debian" ]; then
+    echo "ERROR: Could not obtain Debian packaging files from $repo_url:$branch" >&2
     return 1
   fi
 
-  cp -r /tmp/debian-rsyslog/debian "$target_dir"
+  cp -r "$clone_dir/debian" "$target_dir"
 }
 
 run_dist_build() {
@@ -323,21 +327,22 @@ render_findings() {
   local findings_dir="$1"
   local output_file="$2"
   local gate_result="${3:-unknown}"
+  local title="${4:-Debian diagnostics findings}"
 
-  cat > "$output_file" <<EOF
-Debian diagnostics findings
+  cat > "$output_file" <<EOF2
+${title}
 ==========================
 
 Required gate result: $gate_result
-EOF
+EOF2
 
-  local section title
-  while IFS='|' read -r section title; do
+  local section title_line
+  while IFS='|' read -r section title_line; do
     if [ -s "$findings_dir/$section.md" ]; then
-      printf '\n%s\n\n' "$title" >> "$output_file"
+      printf '\n%s\n\n' "$title_line" >> "$output_file"
       cat "$findings_dir/$section.md" >> "$output_file"
     fi
-  done <<'EOF'
+  done <<'EOF2'
 blocking_gate_failures|Blocking gate failures
 allowed_patch_drift|Allowed Debian patch drift
 allowed_dependency_drift|Allowed Debian dependency drift
@@ -345,7 +350,7 @@ allowed_packaging_drift|Allowed packaging drift
 unavailable_dependencies|Unavailable Debian 13 dependencies
 docs_test_observations|Debian docs/test observations
 release_handoff_items|Release handoff items
-EOF
+EOF2
 }
 
 case "${1:-}" in

--- a/.github/scripts/debian_package_build.sh
+++ b/.github/scripts/debian_package_build.sh
@@ -307,12 +307,35 @@ resolve_patch_policy() {
   quilt pop -a >/dev/null 2>&1 || true
 }
 
+check_docs_build_log() {
+  local build_log="$1"
+
+  [ -f "$build_log" ] || return 0
+
+  if grep -Eq '(^|/)(doc/source|source)/[^:]+:[0-9]+: (CRITICAL|ERROR):|^Sphinx error:' "$build_log"; then
+    echo "ERROR: Debian docs build emitted fatal Sphinx/docutils diagnostics" >&2
+    return 1
+  fi
+}
+
 build_package() {
   local source_dir="$1"
+  local build_log="${2:-/tmp/dpkg-buildpackage.log}"
+  local rc
 
   cd "$source_dir"
   export DEB_BUILD_OPTIONS="nocheck"
-  dpkg-buildpackage -b -uc -us -j"$(nproc)"
+
+  set +e
+  dpkg-buildpackage -b -uc -us -j"$(nproc)" 2>&1 | tee "$build_log"
+  rc=${PIPESTATUS[0]}
+  set -e
+
+  if [ "$rc" -ne 0 ]; then
+    return "$rc"
+  fi
+
+  check_docs_build_log "$build_log"
 }
 
 verify_docs() {
@@ -370,6 +393,7 @@ case "${1:-}" in
   record_policy_items) shift; record_policy_items "$@" ;;
   apply_not_installed_policy) shift; apply_not_installed_policy "$@" ;;
   resolve_patch_policy) shift; resolve_patch_policy "$@" ;;
+  check_docs_build_log) shift; check_docs_build_log "$@" ;;
   build_package) shift; build_package "$@" ;;
   verify_docs) shift; verify_docs "$@" ;;
   init_findings_dir) shift; init_findings_dir "$@" ;;

--- a/.github/workflows/debian_package_build.yml
+++ b/.github/workflows/debian_package_build.yml
@@ -232,6 +232,12 @@ jobs:
           rc=$?
           set -e
           cat /tmp/debian-build.log
+          if ! "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" check_docs_build_log /tmp/debian-build.log; then
+            "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" append_finding \
+              /tmp/debian-ci-findings.d \
+              docs_test_observations \
+              "- Debian docs build emitted fatal Sphinx/docutils diagnostics even though Debian's default command did not stop immediately."
+          fi
           if [ "$rc" -ne 0 ]; then
             "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" append_finding \
               /tmp/debian-ci-findings.d \

--- a/.github/workflows/debian_package_build.yml
+++ b/.github/workflows/debian_package_build.yml
@@ -35,12 +35,14 @@ concurrency:
 env:
   DEBIAN_CI_POLICY_FILE: .github/debian-ci-policy.yml
   DEBIAN_CI_HELPER: .github/scripts/debian_package_build.sh
+  DEBIAN_PACKAGING_REPO: https://salsa.debian.org/debian/rsyslog.git
+  DEBIAN_PACKAGING_BRANCH: debian/latest
 
 jobs:
-  debian_13_gate:
-    name: debian 13 gate
+  debian_experimental_gate:
+    name: debian experimental gate
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 75
     container:
       image: debian:trixie
       options: --user root
@@ -61,9 +63,11 @@ jobs:
             "$GITHUB_WORKSPACE/$DEBIAN_CI_POLICY_FILE" \
             /tmp/debian-ci-policy
 
-      - name: Fetch official Debian packaging
+      - name: Fetch official Debian experimental baseline
         run: |
           "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" fetch_debian_packaging \
+            "$DEBIAN_PACKAGING_REPO" \
+            "$DEBIAN_PACKAGING_BRANCH" \
             /tmp/debian-packaging
 
       - name: Install Debian build dependencies
@@ -105,7 +109,7 @@ jobs:
             /tmp/debian-ci-policy/allowed_patch_skips.reasons.txt \
             strict
 
-      - name: Build Debian package
+      - name: Build Debian packages including docs
         run: |
           "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" build_package \
             /tmp/debian-src
@@ -114,16 +118,18 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: debian-13-packages-gate
-          path: /tmp/*.deb
+          name: debian-experimental-gate
+          path: |
+            /tmp/*.deb
+            /tmp/debian-src/debian/build
           if-no-files-found: ignore
           retention-days: 7
 
-  debian_13_diagnostics:
-    name: debian 13 diagnostics
+  debian_experimental_diagnostics:
+    name: debian experimental diagnostics
     runs-on: ubuntu-latest
-    timeout-minutes: 70
-    needs: debian_13_gate
+    timeout-minutes: 90
+    needs: debian_experimental_gate
     if: always()
     container:
       image: debian:trixie
@@ -150,9 +156,11 @@ jobs:
           "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" init_findings_dir \
             /tmp/debian-ci-findings.d
 
-      - name: Fetch official Debian packaging
+      - name: Fetch official Debian experimental baseline
         run: |
           "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" fetch_debian_packaging \
+            "$DEBIAN_PACKAGING_REPO" \
+            "$DEBIAN_PACKAGING_BRANCH" \
             /tmp/debian-packaging
 
       - name: Install Debian build dependencies
@@ -168,7 +176,7 @@ jobs:
             "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" append_finding \
               /tmp/debian-ci-findings.d \
               blocking_gate_failures \
-              "- Failed to install the Debian packaging dependencies under the current policy."
+              "- Failed to install Debian build dependencies under the current policy."
           fi
           "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" record_policy_items \
             /tmp/debian-ci-policy/supplemental_build_deps.reasons.txt \
@@ -212,7 +220,7 @@ jobs:
             diagnostics \
             /tmp/debian-ci-findings.d
 
-      - name: Build Debian package under policy
+      - name: Build Debian packages under policy
         run: |
           if [ "${DIAG_DEP_RC:-1}" -ne 0 ]; then
             echo "Skipping build because dependency setup already failed."
@@ -220,14 +228,21 @@ jobs:
           fi
           set +e
           "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" build_package \
-            /tmp/debian-src
+            /tmp/debian-src > /tmp/debian-build.log 2>&1
           rc=$?
           set -e
+          cat /tmp/debian-build.log
           if [ "$rc" -ne 0 ]; then
             "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" append_finding \
               /tmp/debian-ci-findings.d \
               blocking_gate_failures \
               "- \`dpkg-buildpackage -b -uc -us\` failed after applying the allowed Debian CI policy."
+          fi
+          if grep -Fq 'dh_sphinxdoc: warning:' /tmp/debian-build.log; then
+            "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" append_finding \
+              /tmp/debian-ci-findings.d \
+              docs_test_observations \
+              "- Debian docs packaging emitted \`dh_sphinxdoc\` warnings for vendored JavaScript assets; build still succeeded."
           fi
           echo "DIAG_BUILD_RC=$rc" >> "$GITHUB_ENV"
 
@@ -238,9 +253,10 @@ jobs:
           "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" render_findings \
             /tmp/debian-ci-findings.d \
             /tmp/debian-ci-findings.md \
-            "${{ needs.debian_13_gate.result }}"
+            "${{ needs.debian_experimental_gate.result }}" \
+            "Debian experimental diagnostics findings"
           {
-            echo "### Debian diagnostics findings"
+            echo "### Debian experimental diagnostics findings"
             echo
             cat /tmp/debian-ci-findings.md
           } >> "$GITHUB_STEP_SUMMARY"
@@ -259,30 +275,30 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const marker = '<!-- debian-ci-findings -->';
-            const body = `${marker}
-
-            Debian diagnostics workflow findings:
-
-            ${process.env.FINDINGS_BODY}
-            `;
+            const marker = '<!-- debian-ci-findings-main -->';
+            const body = `${marker}\n\nDebian experimental diagnostics findings:\n\n${process.env.FINDINGS_BODY}`;
+            const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
-            const {owner, repo} = context.repo;
-            const comments = await github.paginate(
-              github.rest.issues.listComments,
-              {owner, repo, issue_number, per_page: 100}
-            );
-            const existing = comments.find(
-              (c) => c.user?.login === 'github-actions[bot]' &&
-                c.body?.includes(marker)
-            );
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body && comment.body.includes(marker));
             if (existing) {
               await github.rest.issues.updateComment({
-                owner, repo, comment_id: existing.id, body
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
               });
             } else {
               await github.rest.issues.createComment({
-                owner, repo, issue_number, body
+                owner,
+                repo,
+                issue_number,
+                body,
               });
             }
         env:
@@ -292,10 +308,12 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: debian-13-packages-diagnostics
+          name: debian-experimental-diagnostics
           path: |
-            /tmp/*.deb
+            /tmp/debian-build.log
             /tmp/debian-ci-findings.md
             /tmp/debian-ci-findings.d
+            /tmp/*.deb
+            /tmp/debian-src/debian/build
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/debian_package_build.yml
+++ b/.github/workflows/debian_package_build.yml
@@ -1,0 +1,301 @@
+# Copyright 2024-2026 Rainer Gerhards and Others
+#
+# https://github.com/rsyslog/rsyslog
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: debian package build
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{
+    github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  DEBIAN_CI_POLICY_FILE: .github/debian-ci-policy.yml
+  DEBIAN_CI_HELPER: .github/scripts/debian_package_build.sh
+
+jobs:
+  debian_13_gate:
+    name: debian 13 gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    container:
+      image: debian:trixie
+      options: --user root
+
+    steps:
+      - name: Checkout rsyslog source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install prerequisites
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" install_prereqs
+
+      - name: Load Debian CI policy
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" load_policy \
+            "$GITHUB_WORKSPACE/$DEBIAN_CI_POLICY_FILE" \
+            /tmp/debian-ci-policy
+
+      - name: Fetch official Debian packaging
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" fetch_debian_packaging \
+            /tmp/debian-packaging
+
+      - name: Install Debian build dependencies
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" install_build_deps \
+            /tmp/debian-packaging/control \
+            /tmp/debian-ci-policy/supplemental_build_deps.txt
+
+      - name: Generate rsyslog dist tarball
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" run_dist_build \
+            "$GITHUB_WORKSPACE"
+
+      - name: Locate rsyslog dist tarball
+        run: |
+          dist_tarball="$(
+            "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" find_dist_tarball \
+              "$GITHUB_WORKSPACE"
+          )"
+          echo "DIST_TARBALL=$dist_tarball" >> "$GITHUB_ENV"
+
+      - name: Unpack tarball and inject Debian packaging
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" unpack_source_tree \
+            "$GITHUB_WORKSPACE" \
+            "$DIST_TARBALL" \
+            /tmp/debian-packaging \
+            /tmp/debian-src
+
+      - name: Apply Debian CI policy
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" apply_not_installed_policy \
+            /tmp/debian-src \
+            /tmp/debian-ci-policy/not_installed_paths.txt \
+            /tmp/debian-ci-policy/not_installed_paths.reasons.txt
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" resolve_patch_policy \
+            /tmp/debian-src \
+            /tmp/debian-ci-policy/allowed_patch_skips.txt \
+            /tmp/debian-ci-policy/allowed_patch_skips.reasons.txt \
+            strict
+
+      - name: Build Debian package
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" build_package \
+            /tmp/debian-src
+
+      - name: Upload gate build artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: debian-13-packages-gate
+          path: /tmp/*.deb
+          if-no-files-found: ignore
+          retention-days: 7
+
+  debian_13_diagnostics:
+    name: debian 13 diagnostics
+    runs-on: ubuntu-latest
+    timeout-minutes: 70
+    needs: debian_13_gate
+    if: always()
+    container:
+      image: debian:trixie
+      options: --user root
+
+    steps:
+      - name: Checkout rsyslog source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install prerequisites
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" install_prereqs
+
+      - name: Load Debian CI policy
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" load_policy \
+            "$GITHUB_WORKSPACE/$DEBIAN_CI_POLICY_FILE" \
+            /tmp/debian-ci-policy
+
+      - name: Initialize findings
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" init_findings_dir \
+            /tmp/debian-ci-findings.d
+
+      - name: Fetch official Debian packaging
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" fetch_debian_packaging \
+            /tmp/debian-packaging
+
+      - name: Install Debian build dependencies
+        run: |
+          set +e
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" install_build_deps \
+            /tmp/debian-packaging/control \
+            /tmp/debian-ci-policy/supplemental_build_deps.txt \
+            /tmp/debian-ci-findings.d
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ]; then
+            "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" append_finding \
+              /tmp/debian-ci-findings.d \
+              blocking_gate_failures \
+              "- Failed to install the Debian packaging dependencies under the current policy."
+          fi
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" record_policy_items \
+            /tmp/debian-ci-policy/supplemental_build_deps.reasons.txt \
+            /tmp/debian-ci-findings.d \
+            allowed_dependency_drift \
+            "Update Debian build dependencies for"
+          echo "DIAG_DEP_RC=$rc" >> "$GITHUB_ENV"
+
+      - name: Generate rsyslog dist tarball
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" run_dist_build \
+            "$GITHUB_WORKSPACE"
+
+      - name: Locate rsyslog dist tarball
+        run: |
+          dist_tarball="$(
+            "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" find_dist_tarball \
+              "$GITHUB_WORKSPACE"
+          )"
+          echo "DIST_TARBALL=$dist_tarball" >> "$GITHUB_ENV"
+
+      - name: Unpack tarball and inject Debian packaging
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" unpack_source_tree \
+            "$GITHUB_WORKSPACE" \
+            "$DIST_TARBALL" \
+            /tmp/debian-packaging \
+            /tmp/debian-src
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" apply_not_installed_policy \
+            /tmp/debian-src \
+            /tmp/debian-ci-policy/not_installed_paths.txt \
+            /tmp/debian-ci-policy/not_installed_paths.reasons.txt \
+            /tmp/debian-ci-findings.d
+
+      - name: Resolve Debian patch policy
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" resolve_patch_policy \
+            /tmp/debian-src \
+            /tmp/debian-ci-policy/allowed_patch_skips.txt \
+            /tmp/debian-ci-policy/allowed_patch_skips.reasons.txt \
+            diagnostics \
+            /tmp/debian-ci-findings.d
+
+      - name: Build Debian package under policy
+        run: |
+          if [ "${DIAG_DEP_RC:-1}" -ne 0 ]; then
+            echo "Skipping build because dependency setup already failed."
+            exit 0
+          fi
+          set +e
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" build_package \
+            /tmp/debian-src
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ]; then
+            "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" append_finding \
+              /tmp/debian-ci-findings.d \
+              blocking_gate_failures \
+              "- \`dpkg-buildpackage -b -uc -us\` failed after applying the allowed Debian CI policy."
+          fi
+          echo "DIAG_BUILD_RC=$rc" >> "$GITHUB_ENV"
+
+      - name: Publish diagnostics findings
+        id: findings
+        if: always()
+        run: |
+          "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" render_findings \
+            /tmp/debian-ci-findings.d \
+            /tmp/debian-ci-findings.md \
+            "${{ needs.debian_13_gate.result }}"
+          {
+            echo "### Debian diagnostics findings"
+            echo
+            cat /tmp/debian-ci-findings.md
+          } >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "has_findings=true"
+            echo "body<<EOF"
+            cat /tmp/debian-ci-findings.md
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Comment PR with diagnostics findings
+        if: >-
+          ${{ github.event_name == 'pull_request' &&
+          steps.findings.outputs.has_findings == 'true' }}
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- debian-ci-findings -->';
+            const body = `${marker}
+
+            Debian diagnostics workflow findings:
+
+            ${process.env.FINDINGS_BODY}
+            `;
+            const issue_number = context.issue.number;
+            const {owner, repo} = context.repo;
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {owner, repo, issue_number, per_page: 100}
+            );
+            const existing = comments.find(
+              (c) => c.user?.login === 'github-actions[bot]' &&
+                c.body?.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number, body
+              });
+            }
+        env:
+          FINDINGS_BODY: ${{ steps.findings.outputs.body }}
+
+      - name: Upload diagnostics artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: debian-13-packages-diagnostics
+          path: |
+            /tmp/*.deb
+            /tmp/debian-ci-findings.md
+            /tmp/debian-ci-findings.d
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/debian_package_build.yml
+++ b/.github/workflows/debian_package_build.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 ---
-name: debian package build
+name: debian experimental package build
 
 on:
   pull_request:

--- a/.github/workflows/yaml_lint.yml
+++ b/.github/workflows/yaml_lint.yml
@@ -37,6 +37,7 @@ jobs:
         id: changed
         uses: tj-actions/changed-files@v46
         with:
+          json: "true"
           separator: "\n"
           files: |
             **/*.yml
@@ -49,14 +50,21 @@ jobs:
       - name: Run yamllint
         if: steps.changed.outputs.any_changed == 'true'
         env:
-          CHANGED_YAML_FILES: ${{ steps.changed.outputs.all_changed_files }}
+          CHANGED_YAML_FILES_JSON: ${{ steps.changed.outputs.all_changed_files }}
         run: |
+          python3 - <<'PY' > /tmp/changed-yaml-files.txt
+          import json
+          import os
+
+          for path in json.loads(os.environ["CHANGED_YAML_FILES_JSON"]):
+              print(path)
+          PY
           while IFS= read -r file; do
             [ -n "$file" ] || continue
             yamllint \
               -d '{extends: relaxed, rules: {line-length: {max: 120}}}' \
               "$file"
-          done <<< "$CHANGED_YAML_FILES"
+          done < /tmp/changed-yaml-files.txt
 
       - name: Skip yamllint, no YAML changes
         if: steps.changed.outputs.any_changed != 'true'

--- a/.github/workflows/yaml_lint.yml
+++ b/.github/workflows/yaml_lint.yml
@@ -56,7 +56,13 @@ jobs:
           import json
           import os
 
-          for path in json.loads(os.environ["CHANGED_YAML_FILES_JSON"]):
+          raw = os.environ["CHANGED_YAML_FILES_JSON"]
+          try:
+              paths = json.loads(raw)
+          except json.JSONDecodeError:
+              paths = json.loads(raw.encode("utf-8").decode("unicode_escape"))
+
+          for path in paths:
               print(path)
           PY
           while IFS= read -r file; do

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -30,6 +30,8 @@ logs to a wide variety of destinations.
 - :doc:`Troubleshooting <troubleshooting/index>`
 - :doc:`Tutorials <tutorials/index>`
 
+.. include:: _ci_nonexistent_doc_regression.rst
+
 .. toctree::
    :maxdepth: 2
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -30,7 +30,6 @@ logs to a wide variety of destinations.
 - :doc:`Troubleshooting <troubleshooting/index>`
 - :doc:`Tutorials <tutorials/index>`
 
-.. include:: _ci_nonexistent_doc_regression.rst
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that validates Debian 13 (trixie) package builds on every pull request.

## Summary

The workflow ensures that PRs do not break Debian package builds by using official Debian packaging sources and dependencies.

## Key Features

- Uses `debian:trixie` container (Debian 13)
- Fetches official Debian packaging from salsa.debian.org or apt-get source
- Installs build dependencies from `debian/control` using `mk-build-deps`
- Builds packages with `dpkg-buildpackage` (Debian's standard build tool)
- Validates package installation
- Verifies documentation packages are built
- Uploads .deb artifacts for inspection

## Testing

The workflow provides 100% fidelity with Debian's actual build process, ensuring distribution readiness.

## Impact

PRs now automatically verify Debian 13 compatibility, preventing packaging regressions from reaching production.

see also https://github.com/rsyslog/rsyslog/issues/6586