### PR TITLE
msg: check and handle duplicate names when merging JSON objects

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -4708,15 +4708,32 @@ static rsRetVal jsonMerge(struct json_object *existing, struct json_object *json
     struct json_object_iterator it = json_object_iter_begin(json);
     struct json_object_iterator itEnd = json_object_iter_end(json);
     while (!json_object_iter_equal(&it, &itEnd)) {
-        json_object_object_add(existing, json_object_iter_peek_name(&it),
-                               json_object_get(json_object_iter_peek_value(&it)));
+        struct json_object *val = NULL;
+        if(json_object_object_get_ex(existing, json_object_iter_peek_name(&it), &val)) {
+            struct json_object *newVal = json_object_iter_peek_value(&it);
+            if(val != NULL && newVal != NULL &&
+               json_object_get_type(val) == json_type_object &&
+               json_object_get_type(newVal) == json_type_object) {
+                json_object_get(newVal);
+                CHKiRet(jsonMerge(val, newVal));
+            } else {
+                json_object_object_add(existing, json_object_iter_peek_name(&it),
+                                       json_object_get(newVal));
+            }
+        } else {
+            json_object_object_add(existing, json_object_iter_peek_name(&it),
+                                   json_object_get(json_object_iter_peek_value(&it)));
+        }
         json_object_iter_next(&it);
     }
+finalize_it:
     /* note: json-c does ref counting. We added all descandants refcounts
      * in the loop above. So when we now free(_put) the root object, only
      * root gets freed().
      */
-    json_object_put(json);
+    if (json != NULL) {
+        json_object_put(json);
+    }
     RETiRet;
 }
 

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -4709,16 +4709,14 @@ static rsRetVal jsonMerge(struct json_object *existing, struct json_object *json
     struct json_object_iterator itEnd = json_object_iter_end(json);
     while (!json_object_iter_equal(&it, &itEnd)) {
         struct json_object *val = NULL;
-        if(json_object_object_get_ex(existing, json_object_iter_peek_name(&it), &val)) {
+        if (json_object_object_get_ex(existing, json_object_iter_peek_name(&it), &val)) {
             struct json_object *newVal = json_object_iter_peek_value(&it);
-            if(val != NULL && newVal != NULL &&
-               json_object_get_type(val) == json_type_object &&
-               json_object_get_type(newVal) == json_type_object) {
+            if (val != NULL && newVal != NULL && json_object_get_type(val) == json_type_object &&
+                json_object_get_type(newVal) == json_type_object) {
                 json_object_get(newVal);
                 CHKiRet(jsonMerge(val, newVal));
             } else {
-                json_object_object_add(existing, json_object_iter_peek_name(&it),
-                                       json_object_get(newVal));
+                json_object_object_add(existing, json_object_iter_peek_name(&it), json_object_get(newVal));
             }
         } else {
             json_object_object_add(existing, json_object_iter_peek_name(&it),


### PR DESCRIPTION
Fixes the `TODO: check & handle duplicate names` in `runtime/msg.c`.

When merging JSON objects, if a duplicate key is encountered and both values are objects, the objects are now recursively merged. If they are not both objects, the new value overwrites the existing value. This logic accurately handles duplicate keys without leaking memory or crashing.

---
*PR created automatically by Jules for task [13632132299892965873](https://jules.google.com/task/13632132299892965873) started by @rgerhards*