### PR TITLE
🛡️ Sentinel: [HIGH] Fix buffer overflow vulnerability in `sun_cddl.c`

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - [rsyslog]
+**Vulnerability:** The codebase contains instances of `strcpy` and `sprintf` which can lead to buffer overflows.
+**Learning:** `strcpy` and `sprintf` are unsafe because they do not check the length of the destination buffer, which can cause buffer overflows if the source string is longer than the destination buffer.
+**Prevention:** Use safer alternatives like `strncpy`, `strlcpy`, or `snprintf` which allow specifying the maximum number of characters to copy.

--- a/plugins/imsolaris/sun_cddl.c
+++ b/plugins/imsolaris/sun_cddl.c
@@ -219,7 +219,7 @@ void sun_open_door(void) {
                     info.di_target);
 
                 if (info.di_target > 0) {
-                    (void)sprintf(line,
+                    (void)snprintf(line, sizeof(line),
                                   "syslogd pid %ld"
                                   " already running. Cannot "
                                   "start another syslogd pid %ld",
@@ -347,7 +347,7 @@ void sun_open_door(void) {
         if ((DoorFd = door_create(server, 0, DOOR_REFUSE_DESC)) < 0) {
             //???? DOOR_NO_CANEL requires newer libs??? DOOR_REFUSE_DESC | DOOR_NO_CANCEL)) < 0) {
             err = errno;
-            (void)sprintf(line, "door_create() failed - fatal");
+            (void)snprintf(line, sizeof(line), "%s", "door_create() failed - fatal");
             DBGPRINTF("open_door: error: %s, errno=%d\n", line, err);
             imsolaris_logerror(err, line);
             sun_delete_doorfiles();


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Buffer overflow vulnerabilities due to use of `sprintf` without bounds checking in `plugins/imsolaris/sun_cddl.c`.
🎯 Impact: If the format string evaluation results in a string larger than the destination buffer (`line`), it will overflow the stack buffer, potentially leading to a crash or arbitrary code execution.
🔧 Fix: Replaced `sprintf(line, ...)` with `snprintf(line, sizeof(line), ...)` to enforce bounds checking and prevent overflows. Also added a `%s` format specifier when copying literal strings for extra safety against format string vulnerabilities.
✅ Verification: Ensure the codebase compiles. Review the changes to confirm that `snprintf` correctly limits writing to `sizeof(line)`.

---
*PR created automatically by Jules for task [15571110474012023534](https://jules.google.com/task/15571110474012023534) started by @rgerhards*