### PR TITLE
imbeats: add Beats v2 input module

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -1539,6 +1539,70 @@ jobs:
         if: steps.code_changes.outputs.any_changed != 'true'
         run: echo "No relevant changes detected; skipping VictoriaLogs CI."
 
+  imbeats_CI:
+    needs: compile
+    if: ${{ needs.compile.result == 'success' }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    name: imbeats-tests
+    env:
+      DOCKER_RUN_EXTRA_OPTS: >-
+        --network host
+        -v /var/run/docker.sock:/var/run/docker.sock
+        -e GITHUB_WORKSPACE
+    steps:
+      - name: checkout project
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for code changes
+        id: code_changes
+        uses: tj-actions/changed-files@v46
+        with:
+          base_sha: ${{ github.event.pull_request.base.sha }}
+          sha: ${{ github.event.pull_request.head.sha }}
+          files: |
+            tests/imbeats-*.sh
+            tests/yaml-imbeats-*.sh
+            tests/Makefile.am
+            plugins/imbeats/**
+            configure.ac
+            Makefile.am
+            .github/workflows/run_checks.yml
+          files_ignore: |
+            doc/Makefile.am
+
+      - name: run imbeats filebeat docker test
+        if: steps.code_changes.outputs.any_changed == 'true'
+        env:
+          RSYSLOG_DEV_CONTAINER: rsyslog/rsyslog_dev_base_ubuntu:22.04
+          RSYSLOG_CONFIGURE_OPTIONS_OVERRIDE: >-
+            --enable-testbench --enable-omstdout --enable-imdiag --enable-imbeats
+            --disable-default-tests --disable-imtcp-tests --disable-imfile
+            --disable-imfile-tests --disable-fmhttp
+          CI_MAKE_OPT: -j20
+          CI_MAKE_CHECK_OPT: -j1 TESTS=imbeats-filebeat-docker.sh
+          CI_CHECK_CMD: check
+          ABORT_ALL_ON_TEST_FAIL: 'NO'
+          USE_AUTO_DEBUG: 'off'
+          VERBOSE: '1'
+        run: |
+          chmod -R go+rw .
+          devtools/devcontainer.sh --rm devtools/run-ci.sh
+
+      - name: show error logs (if we errored)
+        if: ${{ (failure() || cancelled()) && steps.code_changes.outputs.any_changed == 'true' }}
+        run: |
+          devtools/gather-check-logs.sh
+          cat failed-tests.log
+
+      - name: Skip imbeats CI, no relevant changes
+        if: steps.code_changes.outputs.any_changed != 'true'
+        run: echo "No relevant changes detected; skipping imbeats CI."
+
   clang_analyzer_CI:
     needs: compile
     if: ${{ needs.compile.result == 'success' }}

--- a/.github/workflows/yaml_lint.yml
+++ b/.github/workflows/yaml_lint.yml
@@ -30,6 +30,9 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    env:
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -37,45 +40,22 @@ jobs:
           persist-credentials: false
           fetch-depth: 2
 
-      - name: Identify changed YAML files
-        id: changed
-        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
-        with:
-          json: "true"
-          separator: "\n"
-          files: |
-            **/*.yml
-            **/*.yaml
-
       - name: Install yamllint
-        if: steps.changed.outputs.any_changed == 'true'
         run: pip install yamllint
 
       - name: Run yamllint
-        if: steps.changed.outputs.any_changed == 'true'
-        env:
-          CHANGED_YAML_FILES_JSON: ${{ steps.changed.outputs.all_changed_files }}
         run: |
-          python3 - <<'PY' > /tmp/changed-yaml-files.txt
-          import json
-          import os
+          mapfile -t changed_yaml_files < <(
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- '*.yml' '*.yaml'
+          )
 
-          raw = os.environ["CHANGED_YAML_FILES_JSON"]
-          try:
-              paths = json.loads(raw)
-          except json.JSONDecodeError:
-              paths = json.loads(raw.encode("utf-8").decode("unicode_escape"))
+          if [ "${#changed_yaml_files[@]}" -eq 0 ]; then
+            echo "No YAML files modified"
+            exit 0
+          fi
 
-          for path in paths:
-              print(path)
-          PY
-          while IFS= read -r file; do
-            [ -n "$file" ] || continue
+          for file in "${changed_yaml_files[@]}"; do
             yamllint \
               -d '{extends: relaxed, rules: {line-length: {max: 120}}}' \
               "$file"
-          done < /tmp/changed-yaml-files.txt
-
-      - name: Skip yamllint, no YAML changes
-        if: steps.changed.outputs.any_changed != 'true'
-        run: echo "No YAML files modified"
+          done

--- a/Makefile.am
+++ b/Makefile.am
@@ -194,6 +194,10 @@ if ENABLE_IMDIAG
 SUBDIRS += plugins/imdiag
 endif
 
+if ENABLE_IMBEATS
+SUBDIRS += plugins/imbeats
+endif
+
 if ENABLE_MAIL
 SUBDIRS += plugins/ommail
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -1643,6 +1643,17 @@ AC_ARG_ENABLE(imdiag,
         [enable_imdiag=no]
 )
 
+# imbeats support
+AC_ARG_ENABLE(imbeats,
+        [AS_HELP_STRING([--enable-imbeats],[Enable Beats/Lumberjack v2 input module @<:@default=no@:>@])],
+        [case "${enableval}" in
+         yes) enable_imbeats="yes" ;;
+          no) enable_imbeats="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-imbeats) ;;
+         esac],
+        [enable_imbeats=no]
+)
+
 
 # mmnormalize
 AC_ARG_ENABLE(mmnormalize,
@@ -2544,6 +2555,7 @@ if test "x$enable_imdiag" = "xyes"; then
 	AC_DEFINE([ENABLE_IMDIAG], [1], [Indicator that IMDIAG is present])
 fi
 AM_CONDITIONAL(ENABLE_IMDIAG, test x$enable_imdiag = xyes)
+AM_CONDITIONAL(ENABLE_IMBEATS, test x$enable_imbeats = xyes)
 AM_CONDITIONAL(ENABLE_OMSTDOUT, test x$enable_omstdout = xyes)
 AM_CONDITIONAL(ENABLE_IMPSTATS, test x$enable_impstats = xyes)
 AM_CONDITIONAL(ENABLE_IMPSTATS_PUSH, test x$enable_impstats_push = xyes)
@@ -3509,6 +3521,7 @@ AC_CONFIG_FILES([Makefile \
 		plugins/impstats/Makefile \
 		plugins/imrelp/Makefile \
 		plugins/imdiag/Makefile \
+		plugins/imbeats/Makefile \
 		plugins/imkafka/Makefile \
 		plugins/omtesting/Makefile \
 		plugins/omgssapi/Makefile \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -183,6 +183,7 @@ EXTRA_DIST = \
     source/configuration/modules/imdiag.rst \
     source/configuration/modules/imdocker.rst \
     source/configuration/modules/imdtls.rst \
+    source/configuration/modules/imbeats.rst \
     source/configuration/modules/imfile.rst \
     source/configuration/modules/imgssapi.rst \
     source/configuration/modules/imhiredis.rst \
@@ -226,6 +227,30 @@ EXTRA_DIST = \
     source/configuration/modules/mmtaghostname.rst \
     source/configuration/modules/mmutf8fix.rst \
     source/configuration/modules/module_workflow.png \
+    source/reference/parameters/imbeats-address.rst \
+    source/reference/parameters/imbeats-gnutlsprioritystring.rst \
+    source/reference/parameters/imbeats-keepalive.rst \
+    source/reference/parameters/imbeats-keepalive-interval.rst \
+    source/reference/parameters/imbeats-keepalive-probes.rst \
+    source/reference/parameters/imbeats-keepalive-time.rst \
+    source/reference/parameters/imbeats-listenportfilename.rst \
+    source/reference/parameters/imbeats-name.rst \
+    source/reference/parameters/imbeats-networknamespace.rst \
+    source/reference/parameters/imbeats-permittedpeer.rst \
+    source/reference/parameters/imbeats-port.rst \
+    source/reference/parameters/imbeats-ruleset.rst \
+    source/reference/parameters/imbeats-streamdriver-authmode.rst \
+    source/reference/parameters/imbeats-streamdriver-cafile.rst \
+    source/reference/parameters/imbeats-streamdriver-certfile.rst \
+    source/reference/parameters/imbeats-streamdriver-checkextendedkeypurpose.rst \
+    source/reference/parameters/imbeats-streamdriver-crlfile.rst \
+    source/reference/parameters/imbeats-streamdriver-keyfile.rst \
+    source/reference/parameters/imbeats-streamdriver-mode.rst \
+    source/reference/parameters/imbeats-streamdriver-name.rst \
+    source/reference/parameters/imbeats-streamdriver-permitexpiredcerts.rst \
+    source/reference/parameters/imbeats-streamdriver-prioritizesan.rst \
+    source/reference/parameters/imbeats-streamdriver-tlsrevocationcheck.rst \
+    source/reference/parameters/imbeats-streamdriver-tlsverifydepth.rst \
     source/configuration/modules/omamqp1.rst \
     source/configuration/modules/omazuredce.rst \
     source/configuration/modules/omazureeventhubs.rst \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -317,6 +317,7 @@ EXTRA_DIST = \
     source/containers/development_images.rst \
     source/containers/dockerlogs.rst \
     source/containers/etl.rst \
+    source/containers/imbeats.rst \
     source/containers/index.rst \
     source/containers/minimal.rst \
     source/containers/standard.rst \

--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -80,3 +80,12 @@ omotel:
   requires_serialization: false
   notes:
     - Transport resources are not yet active; introduce pData locking once they appear.
+
+imbeats:
+  paths: ["plugins/imbeats/"]
+  requires_serialization: true
+  locks:
+    - type: mutex
+      field: instanceConf.mutSessions
+  notes:
+    - Listener threads mutate per-instance session lists under mutSessions.

--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -89,3 +89,8 @@ imbeats:
       field: instanceConf.mutSessions
   notes:
     - Listener threads mutate per-instance session lists under mutSessions.
+    - Use Elastic Agent or Filebeat output.logstash to send Lumberjack v2 traffic to imbeats.
+    - TLS deployments require an installed rsyslog TLS stream-driver package or module, such as rsyslog-gnutls or rsyslog-openssl.
+    - The common Elastic Agent TLS setup validates the rsyslog server certificate but does not present a client certificate; use streamDriver.authMode=anon for that pattern and stricter auth modes only with sender client certificates.
+    - Compressed Lumberjack v2 frames are supported and should be tested with Beats compression enabled.
+    - A concrete sample container definition lives under packaging/docker/rsyslog/imbeats but is not wired into published container builds yet.

--- a/doc/source/configuration/modules/imbeats.rst
+++ b/doc/source/configuration/modules/imbeats.rst
@@ -1,0 +1,256 @@
+******************************
+imbeats: Beats v2 input module
+******************************
+
+.. meta::
+   :description: Receive Elastic Beats data in rsyslog via Lumberjack v2 over TCP or TLS.
+   :keywords: rsyslog, imbeats, beats, lumberjack, elastic, input, tcp, tls
+
+.. summary-start
+imbeats receives Elastic Beats events via Lumberjack protocol v2 over TCP or
+TLS, keeps the original JSON payload in ``msg``, maps decoded event fields into
+the top-level structured tree ``$!``, and stores transport/protocol metadata
+under ``$!metadata!imbeats``.
+.. summary-end
+
+===========================  ===========================================================================
+**Module Name:**             **imbeats**
+**Author:**                  **Adiscon and contributors**
+**Available since:**         **8.2604.0**
+===========================  ===========================================================================
+
+
+Purpose
+=======
+
+``imbeats`` accepts Elastic Beats traffic that uses the Logstash-style
+Lumberjack v2 protocol. The module reuses rsyslog's ``netstrm`` transport
+subsystem, so it can listen via plain TCP or the configured TLS stream driver.
+
+The first implementation supports:
+
+- Lumberjack v2 only
+- ``W`` window frames
+- ``J`` JSON event frames
+- ``C`` compressed frames
+- cumulative ``A`` acknowledgements
+
+The first implementation intentionally optimizes the internal event shape for
+common Elasticsearch-oriented pipelines:
+
+- ``msg`` keeps the original JSON payload
+- decoded Beat event fields are added under top-level ``$!``
+- transport and protocol metadata is stored under ``$!metadata!imbeats``
+
+This default may be revisited later. A user-selectable representation mode is
+not part of the initial release.
+
+
+Module Parameters
+=================
+
+Currently none.
+
+
+Input Parameters
+================
+
+.. list-table::
+   :widths: 34 66
+   :header-rows: 1
+
+   * - Parameter
+     - Summary
+   * - :ref:`param-imbeats-address`
+     - .. include:: ../../reference/parameters/imbeats-address.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-gnutlsprioritystring`
+     - .. include:: ../../reference/parameters/imbeats-gnutlsprioritystring.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-keepalive`
+     - .. include:: ../../reference/parameters/imbeats-keepalive.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-keepalive-interval`
+     - .. include:: ../../reference/parameters/imbeats-keepalive-interval.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-keepalive-probes`
+     - .. include:: ../../reference/parameters/imbeats-keepalive-probes.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-keepalive-time`
+     - .. include:: ../../reference/parameters/imbeats-keepalive-time.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-listenportfilename`
+     - .. include:: ../../reference/parameters/imbeats-listenportfilename.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-name`
+     - .. include:: ../../reference/parameters/imbeats-name.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-networknamespace`
+     - .. include:: ../../reference/parameters/imbeats-networknamespace.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-permittedpeer`
+     - .. include:: ../../reference/parameters/imbeats-permittedpeer.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-port`
+     - .. include:: ../../reference/parameters/imbeats-port.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-ruleset`
+     - .. include:: ../../reference/parameters/imbeats-ruleset.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-streamdriver-authmode`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-authmode.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-streamdriver-cafile`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-cafile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-streamdriver-certfile`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-certfile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-streamdriver-checkextendedkeypurpose`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-checkextendedkeypurpose.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-streamdriver-crlfile`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-crlfile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-streamdriver-keyfile`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-keyfile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-streamdriver-mode`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-mode.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-streamdriver-name`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-name.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-streamdriver-permitexpiredcerts`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-permitexpiredcerts.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-streamdriver-prioritizesan`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-prioritizesan.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-streamdriver-tlsrevocationcheck`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-tlsrevocationcheck.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imbeats-streamdriver-tlsverifydepth`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-tlsverifydepth.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+
+Examples
+========
+
+RainerScript
+------------
+
+.. code-block:: none
+
+   module(load="imbeats")
+
+   input(type="imbeats"
+         port="5044"
+         ruleset="beats_to_es"
+         streamdriver.name="gtls"
+         streamdriver.mode="1"
+         streamdriver.authmode="x509/name"
+         streamdriver.cafile="/etc/rsyslog.d/ca.pem"
+         streamdriver.certfile="/etc/rsyslog.d/server-cert.pem"
+         streamdriver.keyfile="/etc/rsyslog.d/server-key.pem")
+
+   ruleset(name="beats_to_es") {
+     action(type="omfile" file="/var/log/imbeats-debug.log")
+   }
+
+YAML
+----
+
+.. code-block:: yaml
+
+   version: 2
+   modules:
+     - load: imbeats
+
+   inputs:
+     - type: imbeats
+       port: "5044"
+       ruleset: beats_to_es
+       streamdriver.name: gtls
+       streamdriver.mode: 1
+       streamdriver.authmode: x509/name
+       streamdriver.cafile: /etc/rsyslog.d/ca.pem
+       streamdriver.certfile: /etc/rsyslog.d/server-cert.pem
+       streamdriver.keyfile: /etc/rsyslog.d/server-key.pem
+
+   rulesets:
+     - name: beats_to_es
+       script: |
+         action(type="omfile" file="/var/log/imbeats-debug.log")
+
+
+Statistic Counters
+==================
+
+The module exposes these ``impstats`` counters:
+
+- ``connections.accepted``
+- ``connections.closed``
+- ``protocol_errors``
+- ``batches.received``
+- ``batches.acked``
+- ``events.received``
+- ``events.submitted``
+- ``events.failed``
+- ``compressed_frames``
+- ``json_decode_failures``
+- ``ack_failures``
+
+
+.. toctree::
+   :hidden:
+
+   ../../reference/parameters/imbeats-address
+   ../../reference/parameters/imbeats-gnutlsprioritystring
+   ../../reference/parameters/imbeats-keepalive
+   ../../reference/parameters/imbeats-keepalive-interval
+   ../../reference/parameters/imbeats-keepalive-probes
+   ../../reference/parameters/imbeats-keepalive-time
+   ../../reference/parameters/imbeats-listenportfilename
+   ../../reference/parameters/imbeats-name
+   ../../reference/parameters/imbeats-networknamespace
+   ../../reference/parameters/imbeats-permittedpeer
+   ../../reference/parameters/imbeats-port
+   ../../reference/parameters/imbeats-ruleset
+   ../../reference/parameters/imbeats-streamdriver-authmode
+   ../../reference/parameters/imbeats-streamdriver-cafile
+   ../../reference/parameters/imbeats-streamdriver-certfile
+   ../../reference/parameters/imbeats-streamdriver-checkextendedkeypurpose
+   ../../reference/parameters/imbeats-streamdriver-crlfile
+   ../../reference/parameters/imbeats-streamdriver-keyfile
+   ../../reference/parameters/imbeats-streamdriver-mode
+   ../../reference/parameters/imbeats-streamdriver-name
+   ../../reference/parameters/imbeats-streamdriver-permitexpiredcerts
+   ../../reference/parameters/imbeats-streamdriver-prioritizesan
+   ../../reference/parameters/imbeats-streamdriver-tlsrevocationcheck
+   ../../reference/parameters/imbeats-streamdriver-tlsverifydepth

--- a/doc/source/configuration/modules/imbeats.rst
+++ b/doc/source/configuration/modules/imbeats.rst
@@ -3,15 +3,15 @@ imbeats: Beats v2 input module
 ******************************
 
 .. meta::
-   :description: Receive Elastic Beats data in rsyslog via Lumberjack v2 over TCP or TLS.
-   :keywords: rsyslog, imbeats, beats, lumberjack, elastic, input, tcp, tls
+   :description: Receive Elastic Beats and Elastic Agent Logstash output in rsyslog via Lumberjack v2 over TCP or TLS.
+   :keywords: rsyslog, imbeats, beats, elastic agent, filebeat, logstash output, lumberjack, input, tcp, tls
 
 .. summary-start
 
-imbeats receives Elastic Beats events via Lumberjack protocol v2 over TCP or
-TLS, keeps the original JSON payload in ``msg``, maps decoded event fields into
-the top-level structured tree ``$!``, and stores transport/protocol metadata
-under ``$!metadata!imbeats``.
+imbeats receives Elastic Beats and Elastic Agent ``output.logstash`` events via
+Lumberjack protocol v2 over TCP or TLS, keeps the original JSON payload in
+``msg``, maps decoded event fields into the top-level structured tree ``$!``,
+and stores transport/protocol metadata under ``$!metadata!imbeats``.
 
 .. summary-end
 
@@ -25,9 +25,11 @@ under ``$!metadata!imbeats``.
 Purpose
 =======
 
-``imbeats`` accepts Elastic Beats traffic that uses the Logstash-style
-Lumberjack v2 protocol. The module reuses rsyslog's ``netstrm`` transport
-subsystem, so it can listen via plain TCP or the configured TLS stream driver.
+``imbeats`` accepts Elastic Beats and Elastic Agent traffic that uses the
+Logstash-style Lumberjack v2 protocol. Configure Beats or Elastic Agent with
+``output.logstash`` and point it at the rsyslog listener. The module reuses
+rsyslog's ``netstrm`` transport subsystem, so it can listen via plain TCP or
+the configured TLS stream driver.
 
 The first implementation supports:
 
@@ -46,6 +48,97 @@ common Elasticsearch-oriented pipelines:
 
 This default may be revisited later. A user-selectable representation mode is
 not part of the initial release.
+
+
+End-to-end Elastic Agent setup
+==============================
+
+Install rsyslog, ``imbeats``, and a TLS stream-driver package through your
+operating system packages. On Debian or Ubuntu systems using packages that
+ship the GnuTLS stream driver separately, a typical TLS prerequisite is:
+
+.. code-block:: bash
+
+   sudo apt install rsyslog rsyslog-gnutls
+
+If your distribution packages ``imbeats.so`` separately, install that package
+as well. The exact package name depends on the distribution.
+
+The example below listens on the common Beats/Logstash port ``5044`` and uses
+GnuTLS. Replace the certificate paths with files issued for your rsyslog
+receiver host.
+
+.. code-block:: none
+
+   module(load="imbeats")
+
+   input(type="imbeats"
+         port="5044"
+         ruleset="beats_to_file"
+         streamdriver.name="gtls"
+         streamdriver.mode="1"
+         streamdriver.authmode="anon"
+         streamdriver.cafile="/etc/rsyslog.d/tls/ca.pem"
+         streamdriver.certfile="/etc/rsyslog.d/tls/server-cert.pem"
+         streamdriver.keyfile="/etc/rsyslog.d/tls/server-key.pem")
+
+   ruleset(name="beats_to_file") {
+     action(type="omfile" file="/var/log/imbeats.log")
+   }
+
+Configure Elastic Agent or Filebeat to use the Logstash output and point it at
+the rsyslog host:
+
+.. code-block:: yaml
+
+   outputs:
+     default:
+       type: logstash
+       hosts: ["rsyslog.example.net:5044"]
+       compression_level: 9
+       ssl.enabled: true
+       ssl.certificate_authorities:
+         - /etc/elastic-agent/certs/ca.pem
+
+For Filebeat standalone configuration, the same output settings are placed
+under ``output.logstash``:
+
+.. code-block:: yaml
+
+   output.logstash:
+     hosts: ["rsyslog.example.net:5044"]
+     compression_level: 9
+     ssl.enabled: true
+     ssl.certificate_authorities:
+       - /etc/filebeat/certs/ca.pem
+
+Use certificate verification in production. Test-only settings such as
+``ssl.verification_mode: none`` are useful for isolated lab checks but should
+not be used for production ingestion.
+
+The example above lets Elastic Agent or Filebeat validate the rsyslog server
+certificate without requiring the sender to present a client certificate. For
+mutual TLS, also configure the sender with its own client certificate and key,
+then switch the rsyslog listener to the appropriate certificate-validation
+auth mode and permitted peer settings.
+
+
+Troubleshooting Elastic Agent delivery
+======================================
+
+- If rsyslog reports that ``gtls`` or ``ossl`` cannot be loaded, install the
+  matching TLS stream-driver package, such as ``rsyslog-gnutls`` or
+  ``rsyslog-openssl``.
+- If the Beat or Agent logs certificate validation errors, confirm that the
+  sender trusts the CA that issued the rsyslog listener certificate and that
+  the configured host name matches the certificate.
+- If the sender connects but does not deliver events, verify that it is using
+  ``output.logstash`` and not an Elasticsearch or HTTP output.
+- ``imbeats`` accepts compressed Lumberjack v2 frames. Keep compression enabled
+  on the sender unless you are isolating a transport problem.
+- Use the ``events.received``, ``events.submitted``, ``compressed_frames``, and
+  ``protocol_errors`` counters to distinguish traffic, parsing, and protocol
+  failures.
 
 
 Configuration Parameters
@@ -202,7 +295,7 @@ RainerScript
          ruleset="beats_to_es"
          streamdriver.name="gtls"
          streamdriver.mode="1"
-         streamdriver.authmode="x509/name"
+         streamdriver.authmode="anon"
          streamdriver.cafile="/etc/rsyslog.d/ca.pem"
          streamdriver.certfile="/etc/rsyslog.d/server-cert.pem"
          streamdriver.keyfile="/etc/rsyslog.d/server-key.pem")
@@ -226,7 +319,7 @@ YAML
        ruleset: beats_to_es
        streamdriver.name: gtls
        streamdriver.mode: 1
-       streamdriver.authmode: x509/name
+       streamdriver.authmode: anon
        streamdriver.cafile: /etc/rsyslog.d/ca.pem
        streamdriver.certfile: /etc/rsyslog.d/server-cert.pem
        streamdriver.keyfile: /etc/rsyslog.d/server-key.pem

--- a/doc/source/configuration/modules/imbeats.rst
+++ b/doc/source/configuration/modules/imbeats.rst
@@ -7,10 +7,12 @@ imbeats: Beats v2 input module
    :keywords: rsyslog, imbeats, beats, lumberjack, elastic, input, tcp, tls
 
 .. summary-start
+
 imbeats receives Elastic Beats events via Lumberjack protocol v2 over TCP or
 TLS, keeps the original JSON payload in ``msg``, maps decoded event fields into
 the top-level structured tree ``$!``, and stores transport/protocol metadata
 under ``$!metadata!imbeats``.
+
 .. summary-end
 
 ===========================  ===========================================================================
@@ -46,14 +48,17 @@ This default may be revisited later. A user-selectable representation mode is
 not part of the initial release.
 
 
+Configuration Parameters
+========================
+
 Module Parameters
-=================
+-----------------
 
 Currently none.
 
 
 Input Parameters
-================
+----------------
 
 .. list-table::
    :widths: 34 66
@@ -65,94 +70,117 @@ Input Parameters
      - .. include:: ../../reference/parameters/imbeats-address.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-gnutlsprioritystring`
      - .. include:: ../../reference/parameters/imbeats-gnutlsprioritystring.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-keepalive`
      - .. include:: ../../reference/parameters/imbeats-keepalive.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-keepalive-interval`
      - .. include:: ../../reference/parameters/imbeats-keepalive-interval.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-keepalive-probes`
      - .. include:: ../../reference/parameters/imbeats-keepalive-probes.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-keepalive-time`
      - .. include:: ../../reference/parameters/imbeats-keepalive-time.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-listenportfilename`
      - .. include:: ../../reference/parameters/imbeats-listenportfilename.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-name`
      - .. include:: ../../reference/parameters/imbeats-name.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-networknamespace`
      - .. include:: ../../reference/parameters/imbeats-networknamespace.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-permittedpeer`
      - .. include:: ../../reference/parameters/imbeats-permittedpeer.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-port`
      - .. include:: ../../reference/parameters/imbeats-port.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-ruleset`
      - .. include:: ../../reference/parameters/imbeats-ruleset.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-streamdriver-authmode`
      - .. include:: ../../reference/parameters/imbeats-streamdriver-authmode.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-streamdriver-cafile`
      - .. include:: ../../reference/parameters/imbeats-streamdriver-cafile.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-streamdriver-certfile`
      - .. include:: ../../reference/parameters/imbeats-streamdriver-certfile.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-streamdriver-checkextendedkeypurpose`
      - .. include:: ../../reference/parameters/imbeats-streamdriver-checkextendedkeypurpose.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-streamdriver-crlfile`
      - .. include:: ../../reference/parameters/imbeats-streamdriver-crlfile.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-streamdriver-keyfile`
      - .. include:: ../../reference/parameters/imbeats-streamdriver-keyfile.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-streamdriver-mode`
      - .. include:: ../../reference/parameters/imbeats-streamdriver-mode.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-streamdriver-name`
      - .. include:: ../../reference/parameters/imbeats-streamdriver-name.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-streamdriver-permitexpiredcerts`
      - .. include:: ../../reference/parameters/imbeats-streamdriver-permitexpiredcerts.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-streamdriver-prioritizesan`
      - .. include:: ../../reference/parameters/imbeats-streamdriver-prioritizesan.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-streamdriver-tlsrevocationcheck`
      - .. include:: ../../reference/parameters/imbeats-streamdriver-tlsrevocationcheck.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
    * - :ref:`param-imbeats-streamdriver-tlsverifydepth`
      - .. include:: ../../reference/parameters/imbeats-streamdriver-tlsverifydepth.rst
         :start-after: .. summary-start

--- a/doc/source/containers/imbeats.rst
+++ b/doc/source/containers/imbeats.rst
@@ -1,0 +1,107 @@
+.. _containers-sample-imbeats:
+.. _container.sample.rsyslog-imbeats:
+
+rsyslog/rsyslog-imbeats sample
+==============================
+
+.. meta::
+   :description: Sample rsyslog container definition for receiving Elastic Agent and Filebeat Logstash output with imbeats.
+   :keywords: rsyslog, containers, Docker, imbeats, Elastic Agent, Filebeat, Logstash output, Beats, TLS
+
+.. summary-start
+
+The ``rsyslog/rsyslog-imbeats`` sample container definition receives Elastic
+Agent and Filebeat ``output.logstash`` traffic with ``imbeats`` on port
+``5044``. It is a repository sample and is not part of the published rsyslog
+container image family yet.
+
+.. summary-end
+
+.. index::
+   pair: containers; rsyslog-imbeats sample
+   pair: Docker images; imbeats sample
+
+Status
+------
+
+The sample files live in ``packaging/docker/rsyslog/imbeats``. They are not
+wired into the container ``Makefile``, release builds, Docker Hub metadata, or
+``latest`` tagging. Use them as a concrete starting point when you want to run
+an ``imbeats`` receiver in a container.
+
+The sample assumes that the base image or package source provides the package
+containing ``imbeats.so``. It installs ``rsyslog-gnutls`` as a concrete TLS
+stream-driver package example.
+
+Local build
+-----------
+
+Build the sample directly from its directory:
+
+.. code-block:: bash
+
+   docker build \
+     -t rsyslog-imbeats-sample:local \
+     packaging/docker/rsyslog/imbeats
+
+This direct build is separate from the official container image Makefile.
+
+Docker Compose example
+----------------------
+
+.. code-block:: yaml
+
+   services:
+     rsyslog-imbeats:
+       image: rsyslog-imbeats-sample:local
+       ports:
+         - "5044:5044/tcp"
+       environment:
+         IMBEATS_PORT: "5044"
+         TLS_AUTH_MODE: "anon"
+         TLS_CA_FILE: /etc/rsyslog/tls/ca.pem
+         TLS_CERT_FILE: /etc/rsyslog/tls/server-cert.pem
+         TLS_KEY_FILE: /etc/rsyslog/tls/server-key.pem
+         IMBEATS_OUTPUT_FILE: /var/log/imbeats.log
+       volumes:
+         - ./certs:/etc/rsyslog/tls:ro
+         - ./logs:/var/log
+
+Elastic Agent output
+--------------------
+
+Configure Elastic Agent to send Logstash output to the container:
+
+.. code-block:: yaml
+
+   outputs:
+     default:
+       type: logstash
+       hosts: ["rsyslog-imbeats.example.net:5044"]
+       compression_level: 9
+       ssl.enabled: true
+       ssl.certificate_authorities:
+         - /etc/elastic-agent/certs/ca.pem
+
+For Filebeat standalone configuration, use the same settings under
+``output.logstash``.
+
+Operational notes
+-----------------
+
+- The container listens on ``5044/tcp`` by default.
+- TLS is configured through the mounted certificate paths. Install and load a
+  TLS stream-driver package in images derived from this sample.
+- The default ``TLS_AUTH_MODE=anon`` lets Elastic Agent or Filebeat verify the
+  rsyslog server certificate without requiring a client certificate. Use a
+  stricter certificate-validation auth mode only after configuring client
+  certificates on the sender.
+- Production deployments should use certificate verification. Avoid disabling
+  verification except for isolated tests.
+- The sample writes received event JSON to ``/var/log/imbeats.log``. Mount a
+  custom rsyslog snippet when you want to forward to another destination.
+
+.. seealso::
+
+   - :doc:`../configuration/modules/imbeats` - imbeats module reference
+   - :doc:`user_images` - rsyslog user-focused container images

--- a/doc/source/containers/user_images.rst
+++ b/doc/source/containers/user_images.rst
@@ -5,7 +5,7 @@ User-Focused Images
 
 .. meta::
    :description: Official rsyslog container image variants for end users, including minimal, standard, collector, dockerlogs, and ETL roles.
-   :keywords: rsyslog, containers, Docker, minimal, collector, dockerlogs, ETL
+   :keywords: rsyslog, containers, Docker, minimal, collector, dockerlogs, ETL, imbeats
 
 .. summary-start
 
@@ -35,6 +35,12 @@ Available variants include:
   syslog and forwards events to a Vespa HTTP endpoint using ``omhttp``.
 * ``rsyslog/rsyslog-debug`` – planned variant with troubleshooting tools.
 
+Sample container definitions include:
+
+* :doc:`rsyslog/rsyslog-imbeats <imbeats>` – concrete sample for receiving
+  Elastic Agent and Filebeat ``output.logstash`` traffic with ``imbeats``.
+  This sample is not wired into published image builds yet.
+
 .. toctree::
    :maxdepth: 1
 
@@ -43,6 +49,7 @@ Available variants include:
    collector
    dockerlogs
    etl
+   imbeats
 
 Images are built using the layered ``Makefile`` in
 ``packaging/docker/rsyslog``::

--- a/doc/source/reference/parameters/imbeats-address.rst
+++ b/doc/source/reference/parameters/imbeats-address.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-address:
 
+address
+=======
+
 .. meta::
    :description: Bind address for the imbeats listener.
    :keywords: rsyslog, imbeats, address

--- a/doc/source/reference/parameters/imbeats-address.rst
+++ b/doc/source/reference/parameters/imbeats-address.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-address:
+
+.. meta::
+   :description: Bind address for the imbeats listener.
+   :keywords: rsyslog, imbeats, address
+
+.. summary-start
+Bind the imbeats listener to a specific local address instead of all interfaces.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-address.rst
+++ b/doc/source/reference/parameters/imbeats-address.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-address:
+.. _imbeats.parameter.input.address:
 
 address
 =======
@@ -7,6 +8,38 @@ address
    :description: Bind address for the imbeats listener.
    :keywords: rsyslog, imbeats, address
 
+.. index::
+   single: imbeats; address
+   single: address
+
 .. summary-start
+
 Bind the imbeats listener to a specific local address instead of all interfaces.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: address
+:Scope: input
+:Type: string
+:Default: input=all interfaces
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Bind the imbeats listener to a specific local address instead of all interfaces.
+
+Input usage
+-----------
+.. _param-imbeats-input-address:
+.. _imbeats.parameter.input.address-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" address="127.0.0.1")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-gnutlsprioritystring.rst
+++ b/doc/source/reference/parameters/imbeats-gnutlsprioritystring.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-gnutlsprioritystring:
 
+gnutlsPriorityString
+====================
+
 .. meta::
    :description: GnuTLS priority string for imbeats TLS sessions.
    :keywords: rsyslog, imbeats, gnutlsprioritystring

--- a/doc/source/reference/parameters/imbeats-gnutlsprioritystring.rst
+++ b/doc/source/reference/parameters/imbeats-gnutlsprioritystring.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-gnutlsprioritystring:
+
+.. meta::
+   :description: GnuTLS priority string for imbeats TLS sessions.
+   :keywords: rsyslog, imbeats, gnutlsprioritystring
+
+.. summary-start
+Override the GnuTLS priority string used by the selected TLS stream driver.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-gnutlsprioritystring.rst
+++ b/doc/source/reference/parameters/imbeats-gnutlsprioritystring.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-gnutlsprioritystring:
+.. _imbeats.parameter.input.gnutlsprioritystring:
 
 gnutlsPriorityString
 ====================
@@ -7,6 +8,38 @@ gnutlsPriorityString
    :description: GnuTLS priority string for imbeats TLS sessions.
    :keywords: rsyslog, imbeats, gnutlsprioritystring
 
+.. index::
+   single: imbeats; gnutlsPriorityString
+   single: gnutlsPriorityString
+
 .. summary-start
+
 Override the GnuTLS priority string used by the selected TLS stream driver.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: gnutlsPriorityString
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Override the GnuTLS priority string used by the selected TLS stream driver.
+
+Input usage
+-----------
+.. _param-imbeats-input-gnutlsprioritystring:
+.. _imbeats.parameter.input.gnutlsprioritystring-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" gnutlsPriorityString="NORMAL")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-keepalive-interval.rst
+++ b/doc/source/reference/parameters/imbeats-keepalive-interval.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-keepalive-interval:
+
+.. meta::
+   :description: TCP keepalive interval for imbeats sessions.
+   :keywords: rsyslog, imbeats, keepalive interval
+
+.. summary-start
+Set the interval between TCP keepalive probes for imbeats sessions.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-keepalive-interval.rst
+++ b/doc/source/reference/parameters/imbeats-keepalive-interval.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-keepalive-interval:
 
+KeepAlive.Interval
+==================
+
 .. meta::
    :description: TCP keepalive interval for imbeats sessions.
    :keywords: rsyslog, imbeats, keepalive interval

--- a/doc/source/reference/parameters/imbeats-keepalive-interval.rst
+++ b/doc/source/reference/parameters/imbeats-keepalive-interval.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-keepalive-interval:
+.. _imbeats.parameter.input.keepalive-interval:
 
 KeepAlive.Interval
 ==================
@@ -7,6 +8,38 @@ KeepAlive.Interval
    :description: TCP keepalive interval for imbeats sessions.
    :keywords: rsyslog, imbeats, keepalive interval
 
+.. index::
+   single: imbeats; KeepAlive.Interval
+   single: KeepAlive.Interval
+
 .. summary-start
+
 Set the interval between TCP keepalive probes for imbeats sessions.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: KeepAlive.Interval
+:Scope: input
+:Type: integer
+:Default: input=system default
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Set the interval between TCP keepalive probes for imbeats sessions.
+
+Input usage
+-----------
+.. _param-imbeats-input-keepalive-interval:
+.. _imbeats.parameter.input.keepalive-interval-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" keepAlive.interval="10")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-keepalive-probes.rst
+++ b/doc/source/reference/parameters/imbeats-keepalive-probes.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-keepalive-probes:
+
+.. meta::
+   :description: TCP keepalive probe count for imbeats sessions.
+   :keywords: rsyslog, imbeats, keepalive probes
+
+.. summary-start
+Set how many TCP keepalive probes are sent before the peer is considered dead.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-keepalive-probes.rst
+++ b/doc/source/reference/parameters/imbeats-keepalive-probes.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-keepalive-probes:
 
+KeepAlive.Probes
+================
+
 .. meta::
    :description: TCP keepalive probe count for imbeats sessions.
    :keywords: rsyslog, imbeats, keepalive probes

--- a/doc/source/reference/parameters/imbeats-keepalive-probes.rst
+++ b/doc/source/reference/parameters/imbeats-keepalive-probes.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-keepalive-probes:
+.. _imbeats.parameter.input.keepalive-probes:
 
 KeepAlive.Probes
 ================
@@ -7,6 +8,38 @@ KeepAlive.Probes
    :description: TCP keepalive probe count for imbeats sessions.
    :keywords: rsyslog, imbeats, keepalive probes
 
+.. index::
+   single: imbeats; KeepAlive.Probes
+   single: KeepAlive.Probes
+
 .. summary-start
+
 Set how many TCP keepalive probes are sent before the peer is considered dead.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: KeepAlive.Probes
+:Scope: input
+:Type: integer
+:Default: input=system default
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Set how many TCP keepalive probes are sent before the peer is considered dead.
+
+Input usage
+-----------
+.. _param-imbeats-input-keepalive-probes:
+.. _imbeats.parameter.input.keepalive-probes-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" keepAlive.probes="5")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-keepalive-time.rst
+++ b/doc/source/reference/parameters/imbeats-keepalive-time.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-keepalive-time:
+
+.. meta::
+   :description: TCP keepalive idle time for imbeats sessions.
+   :keywords: rsyslog, imbeats, keepalive time
+
+.. summary-start
+Set the idle time before TCP keepalive probing begins on imbeats sessions.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-keepalive-time.rst
+++ b/doc/source/reference/parameters/imbeats-keepalive-time.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-keepalive-time:
 
+KeepAlive.Time
+==============
+
 .. meta::
    :description: TCP keepalive idle time for imbeats sessions.
    :keywords: rsyslog, imbeats, keepalive time

--- a/doc/source/reference/parameters/imbeats-keepalive-time.rst
+++ b/doc/source/reference/parameters/imbeats-keepalive-time.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-keepalive-time:
+.. _imbeats.parameter.input.keepalive-time:
 
 KeepAlive.Time
 ==============
@@ -7,6 +8,38 @@ KeepAlive.Time
    :description: TCP keepalive idle time for imbeats sessions.
    :keywords: rsyslog, imbeats, keepalive time
 
+.. index::
+   single: imbeats; KeepAlive.Time
+   single: KeepAlive.Time
+
 .. summary-start
+
 Set the idle time before TCP keepalive probing begins on imbeats sessions.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: KeepAlive.Time
+:Scope: input
+:Type: integer
+:Default: input=system default
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Set the idle time before TCP keepalive probing begins on imbeats sessions.
+
+Input usage
+-----------
+.. _param-imbeats-input-keepalive-time:
+.. _imbeats.parameter.input.keepalive-time-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" keepAlive.time="30")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-keepalive.rst
+++ b/doc/source/reference/parameters/imbeats-keepalive.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-keepalive:
 
+KeepAlive
+=========
+
 .. meta::
    :description: Enable TCP keepalive for imbeats client sessions.
    :keywords: rsyslog, imbeats, keepalive

--- a/doc/source/reference/parameters/imbeats-keepalive.rst
+++ b/doc/source/reference/parameters/imbeats-keepalive.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-keepalive:
+
+.. meta::
+   :description: Enable TCP keepalive for imbeats client sessions.
+   :keywords: rsyslog, imbeats, keepalive
+
+.. summary-start
+Enable socket-level TCP keepalive on accepted imbeats connections.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-keepalive.rst
+++ b/doc/source/reference/parameters/imbeats-keepalive.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-keepalive:
+.. _imbeats.parameter.input.keepalive:
 
 KeepAlive
 =========
@@ -7,6 +8,38 @@ KeepAlive
    :description: Enable TCP keepalive for imbeats client sessions.
    :keywords: rsyslog, imbeats, keepalive
 
+.. index::
+   single: imbeats; KeepAlive
+   single: KeepAlive
+
 .. summary-start
+
 Enable socket-level TCP keepalive on accepted imbeats connections.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: KeepAlive
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Enable socket-level TCP keepalive on accepted imbeats connections.
+
+Input usage
+-----------
+.. _param-imbeats-input-keepalive:
+.. _imbeats.parameter.input.keepalive-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" keepAlive="on")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-listenportfilename.rst
+++ b/doc/source/reference/parameters/imbeats-listenportfilename.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-listenportfilename:
 
+listenPortFileName
+==================
+
 .. meta::
    :description: Port file for dynamic imbeats listeners.
    :keywords: rsyslog, imbeats, listenPortFileName

--- a/doc/source/reference/parameters/imbeats-listenportfilename.rst
+++ b/doc/source/reference/parameters/imbeats-listenportfilename.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-listenportfilename:
+
+.. meta::
+   :description: Port file for dynamic imbeats listeners.
+   :keywords: rsyslog, imbeats, listenPortFileName
+
+.. summary-start
+Write the actual bound port to a file when the imbeats listener uses port ``0``.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-listenportfilename.rst
+++ b/doc/source/reference/parameters/imbeats-listenportfilename.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-listenportfilename:
+.. _imbeats.parameter.input.listenportfilename:
 
 listenPortFileName
 ==================
@@ -7,6 +8,38 @@ listenPortFileName
    :description: Port file for dynamic imbeats listeners.
    :keywords: rsyslog, imbeats, listenPortFileName
 
+.. index::
+   single: imbeats; listenPortFileName
+   single: listenPortFileName
+
 .. summary-start
+
 Write the actual bound port to a file when the imbeats listener uses port ``0``.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: listenPortFileName
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Write the actual bound port to a file when the imbeats listener uses port ``0``.
+
+Input usage
+-----------
+.. _param-imbeats-input-listenportfilename:
+.. _imbeats.parameter.input.listenportfilename-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" port="0" listenPortFileName="/tmp/imbeats.port")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-name.rst
+++ b/doc/source/reference/parameters/imbeats-name.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-name:
+
+.. meta::
+   :description: Input name for imbeats messages.
+   :keywords: rsyslog, imbeats, name
+
+.. summary-start
+Set the ``inputname`` property used for messages received by this imbeats input.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-name.rst
+++ b/doc/source/reference/parameters/imbeats-name.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-name:
 
+name
+====
+
 .. meta::
    :description: Input name for imbeats messages.
    :keywords: rsyslog, imbeats, name

--- a/doc/source/reference/parameters/imbeats-name.rst
+++ b/doc/source/reference/parameters/imbeats-name.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-name:
+.. _imbeats.parameter.input.name:
 
 name
 ====
@@ -7,6 +8,38 @@ name
    :description: Input name for imbeats messages.
    :keywords: rsyslog, imbeats, name
 
+.. index::
+   single: imbeats; name
+   single: name
+
 .. summary-start
+
 Set the ``inputname`` property used for messages received by this imbeats input.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: name
+:Scope: input
+:Type: string
+:Default: input=imbeats
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Set the ``inputname`` property used for messages received by this imbeats input.
+
+Input usage
+-----------
+.. _param-imbeats-input-name:
+.. _imbeats.parameter.input.name-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" name="imbeats")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-networknamespace.rst
+++ b/doc/source/reference/parameters/imbeats-networknamespace.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-networknamespace:
 
+NetworkNamespace
+================
+
 .. meta::
    :description: Network namespace for imbeats listener sockets.
    :keywords: rsyslog, imbeats, network namespace

--- a/doc/source/reference/parameters/imbeats-networknamespace.rst
+++ b/doc/source/reference/parameters/imbeats-networknamespace.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-networknamespace:
+
+.. meta::
+   :description: Network namespace for imbeats listener sockets.
+   :keywords: rsyslog, imbeats, network namespace
+
+.. summary-start
+Open imbeats listener sockets inside the specified Linux network namespace.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-networknamespace.rst
+++ b/doc/source/reference/parameters/imbeats-networknamespace.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-networknamespace:
+.. _imbeats.parameter.input.networknamespace:
 
 NetworkNamespace
 ================
@@ -7,6 +8,38 @@ NetworkNamespace
    :description: Network namespace for imbeats listener sockets.
    :keywords: rsyslog, imbeats, network namespace
 
+.. index::
+   single: imbeats; NetworkNamespace
+   single: NetworkNamespace
+
 .. summary-start
+
 Open imbeats listener sockets inside the specified Linux network namespace.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: NetworkNamespace
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Open imbeats listener sockets inside the specified Linux network namespace.
+
+Input usage
+-----------
+.. _param-imbeats-input-networknamespace:
+.. _imbeats.parameter.input.networknamespace-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" networkNamespace="ns1")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-permittedpeer.rst
+++ b/doc/source/reference/parameters/imbeats-permittedpeer.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-permittedpeer:
+
+.. meta::
+   :description: Allowed TLS peer names for imbeats.
+   :keywords: rsyslog, imbeats, permittedpeer
+
+.. summary-start
+Restrict accepted TLS peers to the configured certificate names.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-permittedpeer.rst
+++ b/doc/source/reference/parameters/imbeats-permittedpeer.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-permittedpeer:
 
+PermittedPeer
+=============
+
 .. meta::
    :description: Allowed TLS peer names for imbeats.
    :keywords: rsyslog, imbeats, permittedpeer

--- a/doc/source/reference/parameters/imbeats-permittedpeer.rst
+++ b/doc/source/reference/parameters/imbeats-permittedpeer.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-permittedpeer:
+.. _imbeats.parameter.input.permittedpeer:
 
 PermittedPeer
 =============
@@ -7,6 +8,38 @@ PermittedPeer
    :description: Allowed TLS peer names for imbeats.
    :keywords: rsyslog, imbeats, permittedpeer
 
+.. index::
+   single: imbeats; PermittedPeer
+   single: PermittedPeer
+
 .. summary-start
+
 Restrict accepted TLS peers to the configured certificate names.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: PermittedPeer
+:Scope: input
+:Type: array
+:Default: input=none
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Restrict accepted TLS peers to the configured certificate names.
+
+Input usage
+-----------
+.. _param-imbeats-input-permittedpeer:
+.. _imbeats.parameter.input.permittedpeer-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" permittedPeer=["beat.example.net"])
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-port.rst
+++ b/doc/source/reference/parameters/imbeats-port.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-port:
 
+port
+====
+
 .. meta::
    :description: Listening port for imbeats.
    :keywords: rsyslog, imbeats, port

--- a/doc/source/reference/parameters/imbeats-port.rst
+++ b/doc/source/reference/parameters/imbeats-port.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-port:
+
+.. meta::
+   :description: Listening port for imbeats.
+   :keywords: rsyslog, imbeats, port
+
+.. summary-start
+Set the TCP port on which the imbeats listener accepts Lumberjack v2 clients.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-port.rst
+++ b/doc/source/reference/parameters/imbeats-port.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-port:
+.. _imbeats.parameter.input.port:
 
 port
 ====
@@ -7,6 +8,38 @@ port
    :description: Listening port for imbeats.
    :keywords: rsyslog, imbeats, port
 
+.. index::
+   single: imbeats; port
+   single: port
+
 .. summary-start
+
 Set the TCP port on which the imbeats listener accepts Lumberjack v2 clients.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: port
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: yes
+:Introduced: 8.2604.0
+
+Description
+-----------
+Set the TCP port on which the imbeats listener accepts Lumberjack v2 clients.
+
+Input usage
+-----------
+.. _param-imbeats-input-port:
+.. _imbeats.parameter.input.port-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-ruleset.rst
+++ b/doc/source/reference/parameters/imbeats-ruleset.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-ruleset:
 
+ruleset
+=======
+
 .. meta::
    :description: Ruleset binding for imbeats.
    :keywords: rsyslog, imbeats, ruleset

--- a/doc/source/reference/parameters/imbeats-ruleset.rst
+++ b/doc/source/reference/parameters/imbeats-ruleset.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-ruleset:
+
+.. meta::
+   :description: Ruleset binding for imbeats.
+   :keywords: rsyslog, imbeats, ruleset
+
+.. summary-start
+Bind the imbeats input to a specific ruleset instead of the default ruleset.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-ruleset.rst
+++ b/doc/source/reference/parameters/imbeats-ruleset.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-ruleset:
+.. _imbeats.parameter.input.ruleset:
 
 ruleset
 =======
@@ -7,6 +8,38 @@ ruleset
    :description: Ruleset binding for imbeats.
    :keywords: rsyslog, imbeats, ruleset
 
+.. index::
+   single: imbeats; ruleset
+   single: ruleset
+
 .. summary-start
+
 Bind the imbeats input to a specific ruleset instead of the default ruleset.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: ruleset
+:Scope: input
+:Type: string
+:Default: input=default ruleset
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Bind the imbeats input to a specific ruleset instead of the default ruleset.
+
+Input usage
+-----------
+.. _param-imbeats-input-ruleset:
+.. _imbeats.parameter.input.ruleset-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" ruleset="beats")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-authmode.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-authmode.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-streamdriver-authmode:
 
+StreamDriver.AuthMode
+=====================
+
 .. meta::
    :description: TLS authentication mode for imbeats.
    :keywords: rsyslog, imbeats, streamdriver authmode

--- a/doc/source/reference/parameters/imbeats-streamdriver-authmode.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-authmode.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-streamdriver-authmode:
+
+.. meta::
+   :description: TLS authentication mode for imbeats.
+   :keywords: rsyslog, imbeats, streamdriver authmode
+
+.. summary-start
+Set the TLS authentication mode used by the configured imbeats stream driver.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-streamdriver-authmode.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-authmode.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-streamdriver-authmode:
+.. _imbeats.parameter.input.streamdriver-authmode:
 
 StreamDriver.AuthMode
 =====================
@@ -7,6 +8,38 @@ StreamDriver.AuthMode
    :description: TLS authentication mode for imbeats.
    :keywords: rsyslog, imbeats, streamdriver authmode
 
+.. index::
+   single: imbeats; StreamDriver.AuthMode
+   single: StreamDriver.AuthMode
+
 .. summary-start
+
 Set the TLS authentication mode used by the configured imbeats stream driver.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.AuthMode
+:Scope: input
+:Type: string
+:Default: input=anon
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Set the TLS authentication mode used by the configured imbeats stream driver.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-authmode:
+.. _imbeats.parameter.input.streamdriver-authmode-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.authMode="anon")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-cafile.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-cafile.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-streamdriver-cafile:
 
+StreamDriver.CAFile
+===================
+
 .. meta::
    :description: CA file for imbeats TLS validation.
    :keywords: rsyslog, imbeats, streamdriver cafile

--- a/doc/source/reference/parameters/imbeats-streamdriver-cafile.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-cafile.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-streamdriver-cafile:
+
+.. meta::
+   :description: CA file for imbeats TLS validation.
+   :keywords: rsyslog, imbeats, streamdriver cafile
+
+.. summary-start
+Specify the CA bundle used to validate TLS peers for imbeats.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-streamdriver-cafile.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-cafile.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-streamdriver-cafile:
+.. _imbeats.parameter.input.streamdriver-cafile:
 
 StreamDriver.CAFile
 ===================
@@ -7,6 +8,38 @@ StreamDriver.CAFile
    :description: CA file for imbeats TLS validation.
    :keywords: rsyslog, imbeats, streamdriver cafile
 
+.. index::
+   single: imbeats; StreamDriver.CAFile
+   single: StreamDriver.CAFile
+
 .. summary-start
+
 Specify the CA bundle used to validate TLS peers for imbeats.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.CAFile
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Specify the CA bundle used to validate TLS peers for imbeats.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-cafile:
+.. _imbeats.parameter.input.streamdriver-cafile-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.caFile="/etc/rsyslog/ca.pem")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-certfile.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-certfile.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-streamdriver-certfile:
 
+StreamDriver.CertFile
+=====================
+
 .. meta::
    :description: Certificate file for imbeats TLS listeners.
    :keywords: rsyslog, imbeats, streamdriver certfile

--- a/doc/source/reference/parameters/imbeats-streamdriver-certfile.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-certfile.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-streamdriver-certfile:
+
+.. meta::
+   :description: Certificate file for imbeats TLS listeners.
+   :keywords: rsyslog, imbeats, streamdriver certfile
+
+.. summary-start
+Specify the local certificate presented by TLS-enabled imbeats listeners.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-streamdriver-certfile.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-certfile.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-streamdriver-certfile:
+.. _imbeats.parameter.input.streamdriver-certfile:
 
 StreamDriver.CertFile
 =====================
@@ -7,6 +8,38 @@ StreamDriver.CertFile
    :description: Certificate file for imbeats TLS listeners.
    :keywords: rsyslog, imbeats, streamdriver certfile
 
+.. index::
+   single: imbeats; StreamDriver.CertFile
+   single: StreamDriver.CertFile
+
 .. summary-start
+
 Specify the local certificate presented by TLS-enabled imbeats listeners.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.CertFile
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Specify the local certificate presented by TLS-enabled imbeats listeners.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-certfile:
+.. _imbeats.parameter.input.streamdriver-certfile-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.certFile="/etc/rsyslog/cert.pem")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-checkextendedkeypurpose.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-checkextendedkeypurpose.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-streamdriver-checkextendedkeypurpose:
+
+.. meta::
+   :description: Extended key usage enforcement for imbeats TLS peers.
+   :keywords: rsyslog, imbeats, extended key usage
+
+.. summary-start
+Enable extended key usage checks when validating imbeats TLS certificates.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-streamdriver-checkextendedkeypurpose.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-checkextendedkeypurpose.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-streamdriver-checkextendedkeypurpose:
 
+StreamDriver.CheckExtendedKeyPurpose
+====================================
+
 .. meta::
    :description: Extended key usage enforcement for imbeats TLS peers.
    :keywords: rsyslog, imbeats, extended key usage

--- a/doc/source/reference/parameters/imbeats-streamdriver-checkextendedkeypurpose.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-checkextendedkeypurpose.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-streamdriver-checkextendedkeypurpose:
+.. _imbeats.parameter.input.streamdriver-checkextendedkeypurpose:
 
 StreamDriver.CheckExtendedKeyPurpose
 ====================================
@@ -7,6 +8,38 @@ StreamDriver.CheckExtendedKeyPurpose
    :description: Extended key usage enforcement for imbeats TLS peers.
    :keywords: rsyslog, imbeats, extended key usage
 
+.. index::
+   single: imbeats; StreamDriver.CheckExtendedKeyPurpose
+   single: StreamDriver.CheckExtendedKeyPurpose
+
 .. summary-start
+
 Enable extended key usage checks when validating imbeats TLS certificates.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.CheckExtendedKeyPurpose
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Enable extended key usage checks when validating imbeats TLS certificates.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-checkextendedkeypurpose:
+.. _imbeats.parameter.input.streamdriver-checkextendedkeypurpose-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.checkExtendedKeyPurpose="on")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-crlfile.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-crlfile.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-streamdriver-crlfile:
 
+StreamDriver.CRLFile
+====================
+
 .. meta::
    :description: CRL file for imbeats TLS validation.
    :keywords: rsyslog, imbeats, streamdriver crlfile

--- a/doc/source/reference/parameters/imbeats-streamdriver-crlfile.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-crlfile.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-streamdriver-crlfile:
+
+.. meta::
+   :description: CRL file for imbeats TLS validation.
+   :keywords: rsyslog, imbeats, streamdriver crlfile
+
+.. summary-start
+Specify the certificate revocation list file used by TLS-enabled imbeats listeners.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-streamdriver-crlfile.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-crlfile.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-streamdriver-crlfile:
+.. _imbeats.parameter.input.streamdriver-crlfile:
 
 StreamDriver.CRLFile
 ====================
@@ -7,6 +8,38 @@ StreamDriver.CRLFile
    :description: CRL file for imbeats TLS validation.
    :keywords: rsyslog, imbeats, streamdriver crlfile
 
+.. index::
+   single: imbeats; StreamDriver.CRLFile
+   single: StreamDriver.CRLFile
+
 .. summary-start
+
 Specify the certificate revocation list file used by TLS-enabled imbeats listeners.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.CRLFile
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Specify the certificate revocation list file used by TLS-enabled imbeats listeners.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-crlfile:
+.. _imbeats.parameter.input.streamdriver-crlfile-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.crlFile="/etc/rsyslog/crl.pem")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-keyfile.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-keyfile.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-streamdriver-keyfile:
+
+.. meta::
+   :description: Private key file for imbeats TLS listeners.
+   :keywords: rsyslog, imbeats, streamdriver keyfile
+
+.. summary-start
+Specify the private key file used by TLS-enabled imbeats listeners.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-streamdriver-keyfile.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-keyfile.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-streamdriver-keyfile:
 
+StreamDriver.KeyFile
+====================
+
 .. meta::
    :description: Private key file for imbeats TLS listeners.
    :keywords: rsyslog, imbeats, streamdriver keyfile

--- a/doc/source/reference/parameters/imbeats-streamdriver-keyfile.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-keyfile.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-streamdriver-keyfile:
+.. _imbeats.parameter.input.streamdriver-keyfile:
 
 StreamDriver.KeyFile
 ====================
@@ -7,6 +8,38 @@ StreamDriver.KeyFile
    :description: Private key file for imbeats TLS listeners.
    :keywords: rsyslog, imbeats, streamdriver keyfile
 
+.. index::
+   single: imbeats; StreamDriver.KeyFile
+   single: StreamDriver.KeyFile
+
 .. summary-start
+
 Specify the private key file used by TLS-enabled imbeats listeners.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.KeyFile
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Specify the private key file used by TLS-enabled imbeats listeners.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-keyfile:
+.. _imbeats.parameter.input.streamdriver-keyfile-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.keyFile="/etc/rsyslog/key.pem")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-mode.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-mode.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-streamdriver-mode:
 
+StreamDriver.Mode
+=================
+
 .. meta::
    :description: Stream driver mode for imbeats.
    :keywords: rsyslog, imbeats, streamdriver mode

--- a/doc/source/reference/parameters/imbeats-streamdriver-mode.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-mode.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-streamdriver-mode:
+
+.. meta::
+   :description: Stream driver mode for imbeats.
+   :keywords: rsyslog, imbeats, streamdriver mode
+
+.. summary-start
+Select whether imbeats uses plain TCP or a TLS-enabled stream driver mode.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-streamdriver-mode.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-mode.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-streamdriver-mode:
+.. _imbeats.parameter.input.streamdriver-mode:
 
 StreamDriver.Mode
 =================
@@ -7,6 +8,38 @@ StreamDriver.Mode
    :description: Stream driver mode for imbeats.
    :keywords: rsyslog, imbeats, streamdriver mode
 
+.. index::
+   single: imbeats; StreamDriver.Mode
+   single: StreamDriver.Mode
+
 .. summary-start
+
 Select whether imbeats uses plain TCP or a TLS-enabled stream driver mode.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.Mode
+:Scope: input
+:Type: integer
+:Default: input=0
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Select whether imbeats uses plain TCP or a TLS-enabled stream driver mode.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-mode:
+.. _imbeats.parameter.input.streamdriver-mode-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.mode="1")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-name.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-name.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-streamdriver-name:
+
+.. meta::
+   :description: Stream driver backend for imbeats.
+   :keywords: rsyslog, imbeats, streamdriver name
+
+.. summary-start
+Select the netstrm backend used by imbeats, for example ``ptcp``, ``gtls``, or ``ossl``.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-streamdriver-name.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-name.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-streamdriver-name:
 
+StreamDriver.Name
+=================
+
 .. meta::
    :description: Stream driver backend for imbeats.
    :keywords: rsyslog, imbeats, streamdriver name

--- a/doc/source/reference/parameters/imbeats-streamdriver-name.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-name.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-streamdriver-name:
+.. _imbeats.parameter.input.streamdriver-name:
 
 StreamDriver.Name
 =================
@@ -7,6 +8,38 @@ StreamDriver.Name
    :description: Stream driver backend for imbeats.
    :keywords: rsyslog, imbeats, streamdriver name
 
+.. index::
+   single: imbeats; StreamDriver.Name
+   single: StreamDriver.Name
+
 .. summary-start
+
 Select the netstrm backend used by imbeats, for example ``ptcp``, ``gtls``, or ``ossl``.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.Name
+:Scope: input
+:Type: string
+:Default: input=ptcp
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Select the netstrm backend used by imbeats, for example ``ptcp``, ``gtls``, or ``ossl``.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-name:
+.. _imbeats.parameter.input.streamdriver-name-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.name="ossl")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-permitexpiredcerts.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-permitexpiredcerts.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-streamdriver-permitexpiredcerts:
+
+.. meta::
+   :description: Expired certificate policy for imbeats TLS peers.
+   :keywords: rsyslog, imbeats, permitexpiredcerts
+
+.. summary-start
+Control how the imbeats TLS stream driver handles expired peer certificates.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-streamdriver-permitexpiredcerts.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-permitexpiredcerts.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-streamdriver-permitexpiredcerts:
 
+StreamDriver.PermitExpiredCerts
+===============================
+
 .. meta::
    :description: Expired certificate policy for imbeats TLS peers.
    :keywords: rsyslog, imbeats, permitexpiredcerts

--- a/doc/source/reference/parameters/imbeats-streamdriver-permitexpiredcerts.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-permitexpiredcerts.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-streamdriver-permitexpiredcerts:
+.. _imbeats.parameter.input.streamdriver-permitexpiredcerts:
 
 StreamDriver.PermitExpiredCerts
 ===============================
@@ -7,6 +8,38 @@ StreamDriver.PermitExpiredCerts
    :description: Expired certificate policy for imbeats TLS peers.
    :keywords: rsyslog, imbeats, permitexpiredcerts
 
+.. index::
+   single: imbeats; StreamDriver.PermitExpiredCerts
+   single: StreamDriver.PermitExpiredCerts
+
 .. summary-start
+
 Control how the imbeats TLS stream driver handles expired peer certificates.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.PermitExpiredCerts
+:Scope: input
+:Type: string
+:Default: input=off
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Control how the imbeats TLS stream driver handles expired peer certificates.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-permitexpiredcerts:
+.. _imbeats.parameter.input.streamdriver-permitexpiredcerts-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.permitExpiredCerts="off")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-prioritizesan.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-prioritizesan.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-streamdriver-prioritizesan:
 
+StreamDriver.PrioritizeSAN
+==========================
+
 .. meta::
    :description: SAN preference for imbeats TLS name validation.
    :keywords: rsyslog, imbeats, prioritize SAN

--- a/doc/source/reference/parameters/imbeats-streamdriver-prioritizesan.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-prioritizesan.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-streamdriver-prioritizesan:
+
+.. meta::
+   :description: SAN preference for imbeats TLS name validation.
+   :keywords: rsyslog, imbeats, prioritize SAN
+
+.. summary-start
+Prefer subject alternative names over common names when validating imbeats TLS peer names.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-streamdriver-prioritizesan.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-prioritizesan.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-streamdriver-prioritizesan:
+.. _imbeats.parameter.input.streamdriver-prioritizesan:
 
 StreamDriver.PrioritizeSAN
 ==========================
@@ -7,6 +8,38 @@ StreamDriver.PrioritizeSAN
    :description: SAN preference for imbeats TLS name validation.
    :keywords: rsyslog, imbeats, prioritize SAN
 
+.. index::
+   single: imbeats; StreamDriver.PrioritizeSAN
+   single: StreamDriver.PrioritizeSAN
+
 .. summary-start
+
 Prefer subject alternative names over common names when validating imbeats TLS peer names.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.PrioritizeSAN
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Prefer subject alternative names over common names when validating imbeats TLS peer names.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-prioritizesan:
+.. _imbeats.parameter.input.streamdriver-prioritizesan-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.prioritizeSAN="on")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-tlsrevocationcheck.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-tlsrevocationcheck.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-streamdriver-tlsrevocationcheck:
 
+StreamDriver.TlsRevocationCheck
+===============================
+
 .. meta::
    :description: Revocation checking for imbeats TLS peers.
    :keywords: rsyslog, imbeats, tls revocation check

--- a/doc/source/reference/parameters/imbeats-streamdriver-tlsrevocationcheck.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-tlsrevocationcheck.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-streamdriver-tlsrevocationcheck:
+
+.. meta::
+   :description: Revocation checking for imbeats TLS peers.
+   :keywords: rsyslog, imbeats, tls revocation check
+
+.. summary-start
+Enable TLS revocation checking for certificates presented to the imbeats listener.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-streamdriver-tlsrevocationcheck.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-tlsrevocationcheck.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-streamdriver-tlsrevocationcheck:
+.. _imbeats.parameter.input.streamdriver-tlsrevocationcheck:
 
 StreamDriver.TlsRevocationCheck
 ===============================
@@ -7,6 +8,38 @@ StreamDriver.TlsRevocationCheck
    :description: Revocation checking for imbeats TLS peers.
    :keywords: rsyslog, imbeats, tls revocation check
 
+.. index::
+   single: imbeats; StreamDriver.TlsRevocationCheck
+   single: StreamDriver.TlsRevocationCheck
+
 .. summary-start
+
 Enable TLS revocation checking for certificates presented to the imbeats listener.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.TlsRevocationCheck
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Enable TLS revocation checking for certificates presented to the imbeats listener.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-tlsrevocationcheck:
+.. _imbeats.parameter.input.streamdriver-tlsrevocationcheck-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.tlsRevocationCheck="on")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-tlsverifydepth.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-tlsverifydepth.rst
@@ -1,0 +1,9 @@
+.. _param-imbeats-streamdriver-tlsverifydepth:
+
+.. meta::
+   :description: Certificate chain depth for imbeats TLS validation.
+   :keywords: rsyslog, imbeats, tls verify depth
+
+.. summary-start
+Set the maximum certificate chain depth accepted during imbeats TLS validation.
+.. summary-end

--- a/doc/source/reference/parameters/imbeats-streamdriver-tlsverifydepth.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-tlsverifydepth.rst
@@ -1,5 +1,8 @@
 .. _param-imbeats-streamdriver-tlsverifydepth:
 
+StreamDriver.TlsVerifyDepth
+===========================
+
 .. meta::
    :description: Certificate chain depth for imbeats TLS validation.
    :keywords: rsyslog, imbeats, tls verify depth

--- a/doc/source/reference/parameters/imbeats-streamdriver-tlsverifydepth.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-tlsverifydepth.rst
@@ -1,4 +1,5 @@
 .. _param-imbeats-streamdriver-tlsverifydepth:
+.. _imbeats.parameter.input.streamdriver-tlsverifydepth:
 
 StreamDriver.TlsVerifyDepth
 ===========================
@@ -7,6 +8,38 @@ StreamDriver.TlsVerifyDepth
    :description: Certificate chain depth for imbeats TLS validation.
    :keywords: rsyslog, imbeats, tls verify depth
 
+.. index::
+   single: imbeats; StreamDriver.TlsVerifyDepth
+   single: StreamDriver.TlsVerifyDepth
+
 .. summary-start
+
 Set the maximum certificate chain depth accepted during imbeats TLS validation.
+
 .. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.TlsVerifyDepth
+:Scope: input
+:Type: integer
+:Default: input=0
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Set the maximum certificate chain depth accepted during imbeats TLS validation.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-tlsverifydepth:
+.. _imbeats.parameter.input.streamdriver-tlsverifydepth-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.tlsVerifyDepth="5")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/packaging/docker/rsyslog/imbeats/.dockerignore
+++ b/packaging/docker/rsyslog/imbeats/.dockerignore
@@ -1,0 +1,5 @@
+*.sw?
+tmp*
+run
+build.sh
+README*

--- a/packaging/docker/rsyslog/imbeats/10-imbeats.conf
+++ b/packaging/docker/rsyslog/imbeats/10-imbeats.conf
@@ -1,0 +1,19 @@
+# Sample imbeats configuration for a container scaffold.
+# Status: not wired into the container Makefile, release flow, Docker Hub
+# metadata, or latest tags yet.
+
+module(load="imbeats")
+
+ruleset(name="imbeats-output") {
+	action(type="omfile" file=`echo $IMBEATS_OUTPUT_FILE`)
+}
+
+input(type="imbeats"
+	port=`echo $IMBEATS_PORT`
+	ruleset="imbeats-output"
+	streamDriver.Name="gtls"
+	streamDriver.Mode="1"
+	streamDriver.AuthMode=`echo $TLS_AUTH_MODE`
+	streamDriver.caFile=`echo $TLS_CA_FILE`
+	streamDriver.certFile=`echo $TLS_CERT_FILE`
+	streamDriver.keyFile=`echo $TLS_KEY_FILE`)

--- a/packaging/docker/rsyslog/imbeats/Dockerfile
+++ b/packaging/docker/rsyslog/imbeats/Dockerfile
@@ -1,0 +1,47 @@
+# Dockerfile for a sample imbeats rsyslog container.
+# Sample status: this image scaffold is not wired into the rsyslog container
+# Makefile, release flow, Docker Hub metadata, or latest tags yet.
+
+# BASE_IMAGE_TAG may point at a local or published standard rsyslog image.
+ARG BASE_IMAGE_TAG="rsyslog/rsyslog:latest"
+
+FROM ${BASE_IMAGE_TAG}
+
+ARG BASE_IMAGE_TAG
+
+# The standard base image defaults to syslog:adm; switch to root for package
+# installation in this derived sample image.
+USER root
+
+LABEL maintainer="Rainer Gerhards <rgerhards@adiscon.com>"
+LABEL description="Sample rsyslog imbeats container. Not published or wired into release automation."
+LABEL com.adiscon.rsyslog.base.image="${BASE_IMAGE_TAG}"
+LABEL org.opencontainers.image.title="rsyslog/rsyslog-imbeats-sample"
+LABEL org.opencontainers.image.description="Sample-only rsyslog container for a TLS-enabled imbeats input."
+LABEL org.opencontainers.image.source="https://github.com/rsyslog/rsyslog"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install a concrete TLS package example for the gtls stream driver.
+# The package or repository source that provides imbeats.so must also be
+# available in the selected base image or configured apt sources. This sample
+# does not publish or pin such a package.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends rsyslog-gnutls && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY 10-imbeats.conf /etc/rsyslog.d/10-imbeats.conf
+
+EXPOSE 5044/tcp
+
+ENV IMBEATS_PORT="5044"
+ENV TLS_CA_FILE=""
+ENV TLS_CERT_FILE=""
+ENV TLS_KEY_FILE=""
+ENV TLS_AUTH_MODE="anon"
+ENV IMBEATS_OUTPUT_FILE="/var/log/imbeats.log"
+ENV RSYSLOG_ROLE=imbeats-sample
+
+# Inherit CMD from the base image.

--- a/packaging/docker/rsyslog/imbeats/README.md
+++ b/packaging/docker/rsyslog/imbeats/README.md
@@ -1,0 +1,46 @@
+# imbeats sample container
+
+This directory contains a sample-only Docker scaffold for running rsyslog with
+a TLS-enabled `imbeats` input on port `5044/tcp`.
+
+Status: this scaffold is not wired into `packaging/docker/rsyslog/Makefile`,
+release automation, Docker Hub metadata, or `latest` tags yet. Build it
+directly from this directory for local experiments only.
+
+## Build
+
+```sh
+docker build \
+  --build-arg BASE_IMAGE_TAG=rsyslog/rsyslog:latest \
+  -t rsyslog-imbeats-sample .
+```
+
+The Dockerfile installs `rsyslog-gnutls` as a concrete TLS package example.
+The package or package source that provides `imbeats.so` must be available in
+the selected base image or configured apt sources; this sample does not publish
+or pin that package.
+
+## Run
+
+```sh
+docker run --rm -p 5044:5044/tcp \
+  -e TLS_CA_FILE=/run/certs/ca.pem \
+  -e TLS_CERT_FILE=/run/certs/server-cert.pem \
+  -e TLS_KEY_FILE=/run/certs/server-key.pem \
+  -v "$PWD/certs:/run/certs:ro" \
+  rsyslog-imbeats-sample
+```
+
+Environment variables:
+
+- `IMBEATS_PORT`: input port, defaults to `5044`.
+- `TLS_CA_FILE`: CA file path passed to the imbeats TLS stream driver.
+- `TLS_CERT_FILE`: server certificate path.
+- `TLS_KEY_FILE`: server key path.
+- `TLS_AUTH_MODE`: stream driver auth mode, defaults to `anon`.
+- `IMBEATS_OUTPUT_FILE`: output file, defaults to `/var/log/imbeats.log`.
+
+The default `TLS_AUTH_MODE=anon` matches the common Elastic Agent and Filebeat
+setup where the sender verifies the rsyslog server certificate but does not
+present a client certificate. Use a stricter certificate-validation auth mode
+only after configuring client certificates on the sender.

--- a/plugins/imbeats/MODULE_METADATA.yaml
+++ b/plugins/imbeats/MODULE_METADATA.yaml
@@ -1,0 +1,9 @@
+support_status: core-supported
+maturity_level: fresh
+primary_contact: "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>"
+last_reviewed: 2026-04-09
+build_dependencies:
+  - "zlib (--enable-imbeats)"
+notes:
+  - "Accepts Elastic Beats via Lumberjack protocol v2 over netstrm-backed TCP or TLS transports."
+  - "Initial event mapping is optimized for Elasticsearch-oriented downstream flow; representation configurability is deferred."

--- a/plugins/imbeats/Makefile.am
+++ b/plugins/imbeats/Makefile.am
@@ -1,0 +1,6 @@
+pkglib_LTLIBRARIES = imbeats.la
+
+imbeats_la_SOURCES = imbeats.c lj_parser.c lj_parser.h
+imbeats_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(ZLIB_CFLAGS)
+imbeats_la_LDFLAGS = -module -avoid-version $(ZLIB_LIBS)
+imbeats_la_LIBADD =

--- a/plugins/imbeats/README.md
+++ b/plugins/imbeats/README.md
@@ -1,0 +1,22 @@
+# imbeats Notes
+
+`imbeats` is a dedicated Beats/Lumberjack v2 input module built on rsyslog's
+`netstrm` transport subsystem instead of `tcpsrv`.
+
+## Deferred Representation Decision
+
+The first implementation maps decoded Beat event fields into the top-level
+structured message tree `$!` and keeps the original JSON payload in `msg`.
+Transport and protocol metadata is stored under `$!metadata!imbeats`.
+
+This shape is intentional for the common pipeline:
+
+- receive Beat events in rsyslog
+- process or route in rsyslog
+- finally emit JSON to Elasticsearch with minimal reshaping
+
+This is **not** the only valid representation. A more rsyslog-native split such
+as `msg + $!beats + $!metadata!imbeats` remains a reasonable alternative.
+
+The long-term default and any user-selectable representation mode need to be
+decided later based on real usage and operator feedback.

--- a/plugins/imbeats/imbeats.c
+++ b/plugins/imbeats/imbeats.c
@@ -1,0 +1,964 @@
+/* imbeats.c
+ * Input module for Elastic Beats / Lumberjack v2.
+ *
+ * Transport and TLS are delegated to the netstrm subsystem. Protocol parsing,
+ * JSON decoding, and ACK timing live here.
+ */
+#include "config.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <poll.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+#include <libfastjson/json.h>
+#include <libfastjson/json_tokener.h>
+
+#include "rsyslog.h"
+#include "cfsysline.h"
+#include "module-template.h"
+#include "errmsg.h"
+#include "unicode-helper.h"
+#include "net.h"
+#include "netstrm.h"
+#include "ruleset.h"
+#include "prop.h"
+#include "statsobj.h"
+#include "msg.h"
+#include "dirty.h"
+#include "glbl.h"
+#include "ratelimit.h"
+#include "srUtils.h"
+#include "tcpsrv.h"
+
+#include "lj_parser.h"
+
+MODULE_TYPE_INPUT;
+MODULE_TYPE_NOKEEP;
+MODULE_CNFNAME("imbeats")
+
+DEF_IMOD_STATIC_DATA;
+DEFobjCurrIf(glbl) DEFobjCurrIf(net) DEFobjCurrIf(netstrm) DEFobjCurrIf(netstrms) DEFobjCurrIf(prop)
+    DEFobjCurrIf(ruleset) DEFobjCurrIf(statsobj)
+
+        typedef struct session_s session_t;
+
+typedef struct instanceConf_s {
+    struct instanceConf_s *next;
+    uchar *port;
+    uchar *address;
+    uchar *pszBindRuleset;
+    ruleset_t *pBindRuleset;
+    uchar *pszInputName;
+    prop_t *pInputName;
+    uchar *pszLstnPortFileName;
+    char *pszNetworkNamespace;
+
+    uchar *pszStrmDrvrName;
+    int iStrmDrvrMode;
+    uchar *pszStrmDrvrAuthMode;
+    uchar *pszStrmDrvrPermitExpiredCerts;
+    uchar *pszStrmDrvrCAFile;
+    uchar *pszStrmDrvrCRLFile;
+    uchar *pszStrmDrvrKeyFile;
+    uchar *pszStrmDrvrCertFile;
+    uchar *gnutlsPriorityString;
+    permittedPeers_t *pPermPeersRoot;
+    int iStrmDrvrExtendedCertCheck;
+    int iStrmDrvrSANPreference;
+    int iStrmTlsVerifyDepth;
+    int iStrmTlsRevocationCheck;
+
+    int bKeepAlive;
+    int iKeepAliveIntvl;
+    int iKeepAliveProbes;
+    int iKeepAliveTime;
+
+    netstrms_t *pNS;
+    netstrm_t **listeners;
+    int *listener_socks;
+    size_t listener_count;
+    size_t listener_cap;
+    pthread_t listener_tid;
+    int listener_running;
+    pthread_mutex_t mutSessions;
+    session_t *sessions;
+} instanceConf_t;
+
+typedef struct modConfData_s {
+    rsconf_t *pConf;
+    instanceConf_t *root;
+    instanceConf_t *tail;
+} modConfData_t;
+
+struct session_s {
+    instanceConf_t *inst;
+    netstrm_t *pStrm;
+    pthread_t tid;
+    int done;
+    int sock;
+    uchar *fromHostFQDN;
+    prop_t *fromHost;
+    prop_t *fromHostIP;
+    prop_t *fromHostPort;
+    session_t *next;
+};
+
+static modConfData_t *loadModConf = NULL;
+static modConfData_t *runModConf = NULL;
+static prop_t *pInputName = NULL;
+
+static struct cnfparamdescr modpdescr[] = {};
+static struct cnfparamblk modpblk = {CNFPARAMBLK_VERSION, 0, modpdescr};
+
+static struct cnfparamdescr inppdescr[] = {
+    {"port", eCmdHdlrString, CNFPARAM_REQUIRED},
+    {"address", eCmdHdlrString, 0},
+    {"ruleset", eCmdHdlrString, 0},
+    {"name", eCmdHdlrString, 0},
+    {"listenportfilename", eCmdHdlrString, 0},
+    {"networknamespace", eCmdHdlrString, 0},
+    {"streamdriver.name", eCmdHdlrString, 0},
+    {"streamdriver.mode", eCmdHdlrNonNegInt, 0},
+    {"streamdriver.authmode", eCmdHdlrString, 0},
+    {"streamdriver.permitexpiredcerts", eCmdHdlrString, 0},
+    {"streamdriver.cafile", eCmdHdlrString, 0},
+    {"streamdriver.crlfile", eCmdHdlrString, 0},
+    {"streamdriver.keyfile", eCmdHdlrString, 0},
+    {"streamdriver.certfile", eCmdHdlrString, 0},
+    {"streamdriver.checkextendedkeypurpose", eCmdHdlrBinary, 0},
+    {"streamdriver.prioritizesan", eCmdHdlrBinary, 0},
+    {"streamdriver.tlsverifydepth", eCmdHdlrPositiveInt, 0},
+    {"streamdriver.tlsrevocationcheck", eCmdHdlrBinary, 0},
+    {"permittedpeer", eCmdHdlrArray, 0},
+    {"keepalive", eCmdHdlrBinary, 0},
+    {"keepalive.probes", eCmdHdlrNonNegInt, 0},
+    {"keepalive.time", eCmdHdlrNonNegInt, 0},
+    {"keepalive.interval", eCmdHdlrNonNegInt, 0},
+    {"gnutlsprioritystring", eCmdHdlrString, 0},
+};
+static struct cnfparamblk inppblk = {CNFPARAMBLK_VERSION, sizeof(inppdescr) / sizeof(inppdescr[0]), inppdescr};
+
+static struct {
+    statsobj_t *stats;
+    STATSCOUNTER_DEF(ctrConnectionsAccepted, mutCtrConnectionsAccepted)
+    STATSCOUNTER_DEF(ctrConnectionsClosed, mutCtrConnectionsClosed)
+    STATSCOUNTER_DEF(ctrProtocolErrors, mutCtrProtocolErrors)
+    STATSCOUNTER_DEF(ctrBatchesReceived, mutCtrBatchesReceived)
+    STATSCOUNTER_DEF(ctrBatchesAcked, mutCtrBatchesAcked)
+    STATSCOUNTER_DEF(ctrEventsReceived, mutCtrEventsReceived)
+    STATSCOUNTER_DEF(ctrEventsSubmitted, mutCtrEventsSubmitted)
+    STATSCOUNTER_DEF(ctrEventsFailed, mutCtrEventsFailed)
+    STATSCOUNTER_DEF(ctrCompressedFrames, mutCtrCompressedFrames)
+    STATSCOUNTER_DEF(ctrJsonDecodeFailures, mutCtrJsonDecodeFailures)
+    STATSCOUNTER_DEF(ctrAckFailures, mutCtrAckFailures)
+} statsCounter;
+
+#include "im-helper.h"
+
+static inline void std_checkRuleset_genErrMsg(__attribute__((unused)) modConfData_t *modConf, instanceConf_t *inst) {
+    LogError(0, NO_ERRCODE, "imbeats: ruleset '%s' for port '%s' not found - using default ruleset instead",
+             inst->pszBindRuleset, inst->port);
+}
+
+static rsRetVal createInstance(instanceConf_t **const pinst);
+static rsRetVal buildListeners(instanceConf_t *inst);
+static rsRetVal destroyInstanceRuntime(instanceConf_t *inst);
+static void *listenerThread(void *arg);
+static void *sessionThread(void *arg);
+
+static rsRetVal createPortProp(struct sockaddr_storage *addr, prop_t **const ppProp) {
+    uint16_t port = 0;
+    char portbuf[8];
+    DEFiRet;
+
+    if (addr->ss_family == AF_INET) {
+        port = ntohs(((struct sockaddr_in *)addr)->sin_port);
+    } else if (addr->ss_family == AF_INET6) {
+        port = ntohs(((struct sockaddr_in6 *)addr)->sin6_port);
+    }
+    snprintf(portbuf, sizeof(portbuf), "%u", port);
+    CHKiRet(prop.Construct(ppProp));
+    CHKiRet(prop.SetString(*ppProp, (uchar *)portbuf, strlen(portbuf)));
+    CHKiRet(prop.ConstructFinalize(*ppProp));
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal addListener(void *usr, netstrm_t *pStrm) {
+    instanceConf_t *const inst = (instanceConf_t *)usr;
+    int sock = -1;
+    netstrm_t **new_listeners;
+    int *new_socks;
+    DEFiRet;
+
+    assert(inst != NULL);
+    assert(pStrm != NULL);
+
+    if (inst->listener_count == inst->listener_cap) {
+        size_t new_cap = (inst->listener_cap == 0) ? 4 : inst->listener_cap * 2;
+        new_listeners = realloc(inst->listeners, new_cap * sizeof(netstrm_t *));
+        new_socks = realloc(inst->listener_socks, new_cap * sizeof(int));
+        if (new_listeners == NULL || new_socks == NULL) {
+            free(new_listeners);
+            free(new_socks);
+            return RS_RET_OUT_OF_MEMORY;
+        }
+        inst->listeners = new_listeners;
+        inst->listener_socks = new_socks;
+        inst->listener_cap = new_cap;
+    }
+
+    CHKiRet(netstrm.GetSock(pStrm, &sock));
+    inst->listeners[inst->listener_count] = pStrm;
+    inst->listener_socks[inst->listener_count] = sock;
+    ++inst->listener_count;
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal configureNetstrms(instanceConf_t *const inst) {
+    DEFiRet;
+    assert(inst != NULL);
+
+    CHKiRet(netstrms.Construct(&inst->pNS));
+    if (inst->pszStrmDrvrName != NULL) CHKiRet(netstrms.SetDrvrName(inst->pNS, inst->pszStrmDrvrName));
+    CHKiRet(netstrms.SetDrvrMode(inst->pNS, inst->iStrmDrvrMode));
+    CHKiRet(netstrms.SetDrvrCheckExtendedKeyUsage(inst->pNS, inst->iStrmDrvrExtendedCertCheck));
+    CHKiRet(netstrms.SetDrvrPrioritizeSAN(inst->pNS, inst->iStrmDrvrSANPreference));
+    CHKiRet(netstrms.SetDrvrTlsVerifyDepth(inst->pNS, inst->iStrmTlsVerifyDepth));
+    CHKiRet(netstrms.SetDrvrTlsRevocationCheck(inst->pNS, inst->iStrmTlsRevocationCheck));
+    if (inst->pszStrmDrvrAuthMode != NULL) CHKiRet(netstrms.SetDrvrAuthMode(inst->pNS, inst->pszStrmDrvrAuthMode));
+    CHKiRet(netstrms.SetDrvrPermitExpiredCerts(inst->pNS, inst->pszStrmDrvrPermitExpiredCerts));
+    CHKiRet(netstrms.SetDrvrTlsCAFile(inst->pNS, inst->pszStrmDrvrCAFile));
+    CHKiRet(netstrms.SetDrvrTlsCRLFile(inst->pNS, inst->pszStrmDrvrCRLFile));
+    CHKiRet(netstrms.SetDrvrTlsKeyFile(inst->pNS, inst->pszStrmDrvrKeyFile));
+    CHKiRet(netstrms.SetDrvrTlsCertFile(inst->pNS, inst->pszStrmDrvrCertFile));
+    if (inst->pPermPeersRoot != NULL) CHKiRet(netstrms.SetDrvrPermPeers(inst->pNS, inst->pPermPeersRoot));
+    if (inst->gnutlsPriorityString != NULL)
+        CHKiRet(netstrms.SetDrvrGnutlsPriorityString(inst->pNS, inst->gnutlsPriorityString));
+    CHKiRet(netstrms.ConstructFinalize(inst->pNS));
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal buildListeners(instanceConf_t *inst) {
+    tcpLstnParams_t params;
+    DEFiRet;
+
+    memset(&params, 0, sizeof(params));
+    params.pszPort = inst->port;
+    params.pszAddr = inst->address;
+    params.pszLstnPortFileName = inst->pszLstnPortFileName;
+    params.pszNetworkNamespace = inst->pszNetworkNamespace;
+
+    CHKiRet(configureNetstrms(inst));
+    CHKiRet(netstrm.LstnInit(inst->pNS, inst, addListener, 0, &params));
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal sessionPollWait(const int fd, const short events, const int timeout_ms) {
+    struct pollfd pfd;
+    pfd.fd = fd;
+    pfd.events = events;
+    pfd.revents = 0;
+    if (poll(&pfd, 1, timeout_ms) < 0) {
+        return RS_RET_IO_ERROR;
+    }
+    return RS_RET_OK;
+}
+
+static rsRetVal sessionRead(session_t *const sess, unsigned char *buf, const size_t len) {
+    size_t off = 0;
+    int oserr;
+    unsigned nextIODirection;
+    rsRetVal iRet;
+
+    assert(sess != NULL);
+    while (off < len && glbl.GetGlobalInputTermState() == 0) {
+        ssize_t need = (ssize_t)(len - off);
+        iRet = netstrm.Rcv(sess->pStrm, buf + off, &need, &oserr, &nextIODirection);
+        if (iRet == RS_RET_OK) {
+            off += need;
+        } else if (iRet == RS_RET_RETRY) {
+            CHKiRet(sessionPollWait(sess->sock, (nextIODirection == NSDSEL_WR) ? POLLOUT : POLLIN, 1000));
+        } else {
+            ABORT_FINALIZE(iRet);
+        }
+    }
+
+    if (off != len) {
+        ABORT_FINALIZE(RS_RET_CLOSED);
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal sessionSendAll(session_t *const sess, const unsigned char *buf, const size_t len) {
+    size_t off = 0;
+    rsRetVal iRet;
+
+    while (off < len && glbl.GetGlobalInputTermState() == 0) {
+        ssize_t to_send = (ssize_t)(len - off);
+        iRet = netstrm.Send(sess->pStrm, (uchar *)buf + off, &to_send);
+        if (iRet == RS_RET_OK) {
+            if (to_send == 0) {
+                CHKiRet(sessionPollWait(sess->sock, POLLOUT, 1000));
+            } else {
+                off += to_send;
+            }
+        } else {
+            ABORT_FINALIZE(iRet);
+        }
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal submitEvent(session_t *const sess, const struct lj_event_s *const event) {
+    smsg_t *pMsg = NULL;
+    struct json_tokener *tok = NULL;
+    struct fjson_object *json = NULL;
+    struct fjson_object *meta = NULL;
+    rsRetVal iRet = RS_RET_OK;
+    char portbuf[16];
+
+    assert(sess != NULL);
+    assert(event != NULL);
+
+    CHKmalloc(tok = json_tokener_new());
+    json = json_tokener_parse_ex(tok, (const char *)event->payload, event->payload_len);
+    if (tok->err != fjson_tokener_success || json == NULL || !fjson_object_is_type(json, fjson_type_object)) {
+        STATSCOUNTER_INC(statsCounter.ctrJsonDecodeFailures, statsCounter.mutCtrJsonDecodeFailures);
+        ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+    }
+
+    CHKiRet(msgConstruct(&pMsg));
+    MsgSetFlowControlType(pMsg, eFLOWCTL_LIGHT_DELAY);
+    MsgSetInputName(pMsg, (sess->inst->pInputName != NULL) ? sess->inst->pInputName : pInputName);
+    MsgSetRawMsg(pMsg, (const char *)event->payload, event->payload_len);
+    MsgSetMSGoffs(pMsg, 0);
+    if (sess->fromHostFQDN != NULL) {
+        if (sess->fromHost != NULL) {
+            MsgSetRcvFrom(pMsg, sess->fromHost);
+        }
+        MsgSetHOSTNAME(pMsg, sess->fromHostFQDN, ustrlen(sess->fromHostFQDN));
+    }
+    if (sess->fromHostIP != NULL) {
+        CHKiRet(MsgSetRcvFromIP(pMsg, sess->fromHostIP));
+    }
+    if (sess->fromHostPort != NULL) {
+        CHKiRet(MsgSetRcvFromPort(pMsg, sess->fromHostPort));
+    }
+    if (sess->inst->pBindRuleset != NULL) {
+        MsgSetRuleset(pMsg, sess->inst->pBindRuleset);
+    }
+
+    /* TODO: representation mode is intentionally Elasticsearch-oriented for v1.
+     * Revisit later whether this should be configurable (for example $! vs $!beats).
+     */
+    CHKiRet(msgAddJSON(pMsg, (uchar *)"!", json, 0, 0));
+    json = NULL;
+
+    CHKmalloc(meta = json_object_new_object());
+    fjson_object_object_add(meta, "protocol", json_object_new_string("lumberjack-v2"));
+    fjson_object_object_add(meta, "sequence", json_object_new_int64(event->seq));
+    fjson_object_object_add(meta, "tls_enabled", json_object_new_boolean(sess->inst->iStrmDrvrMode != 0));
+    if (sess->fromHostFQDN != NULL) {
+        fjson_object_object_add(meta, "peer_hostname", json_object_new_string((char *)sess->fromHostFQDN));
+    }
+    if (sess->fromHostIP != NULL) {
+        fjson_object_object_add(meta, "peer_ip", json_object_new_string(propGetSzStrOrDefault(sess->fromHostIP, "")));
+    }
+    if (sess->fromHostPort != NULL) {
+        snprintf(portbuf, sizeof(portbuf), "%s", propGetSzStrOrDefault(sess->fromHostPort, ""));
+        fjson_object_object_add(meta, "peer_port", json_object_new_string(portbuf));
+    }
+    CHKiRet(msgAddJSON(pMsg, (uchar *)"!metadata!imbeats", meta, 0, 0));
+    meta = NULL;
+
+    CHKiRet(submitMsg2(pMsg));
+    STATSCOUNTER_INC(statsCounter.ctrEventsSubmitted, statsCounter.mutCtrEventsSubmitted);
+
+finalize_it:
+    if (iRet != RS_RET_OK) {
+        STATSCOUNTER_INC(statsCounter.ctrEventsFailed, statsCounter.mutCtrEventsFailed);
+        if (pMsg != NULL) {
+            msgDestruct(&pMsg);
+        }
+    }
+    if (tok != NULL) {
+        json_tokener_free(tok);
+    }
+    if (json != NULL) {
+        fjson_object_put(json);
+    }
+    if (meta != NULL) {
+        fjson_object_put(meta);
+    }
+    RETiRet;
+}
+
+static rsRetVal receiveBatch(session_t *const sess, struct lj_batch_s *batch) {
+    unsigned char hdr[2];
+    uint32_t net32;
+    uint32_t seq = 0;
+    size_t idx;
+    DEFiRet;
+
+    CHKiRet(sessionRead(sess, hdr, sizeof(hdr)));
+    CHKiRet(sessionRead(sess, (unsigned char *)&net32, sizeof(net32)));
+    net32 = ntohl(net32);
+    CHKiRet(lj_parse_window_header(hdr, net32));
+    CHKiRet(lj_batch_alloc(batch, net32));
+    STATSCOUNTER_INC(statsCounter.ctrBatchesReceived, statsCounter.mutCtrBatchesReceived);
+
+    while (batch->count < batch->window_size) {
+        unsigned char frame_hdr[2];
+        CHKiRet(sessionRead(sess, frame_hdr, sizeof(frame_hdr)));
+        if (frame_hdr[0] != LJ_VERSION_V2) {
+            ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+        }
+        if (frame_hdr[1] == LJ_FRAME_JSON) {
+            uint32_t payload_len;
+            unsigned char *payload;
+            CHKiRet(sessionRead(sess, (unsigned char *)&net32, sizeof(net32)));
+            seq = ntohl(net32);
+            CHKiRet(sessionRead(sess, (unsigned char *)&net32, sizeof(net32)));
+            payload_len = ntohl(net32);
+            CHKmalloc(payload = malloc(payload_len));
+            CHKiRet(sessionRead(sess, payload, payload_len));
+            iRet = lj_append_json_event(batch, seq, payload, payload_len);
+            free(payload);
+            CHKiRet(iRet);
+        } else if (frame_hdr[1] == LJ_FRAME_COMPRESSED) {
+            uint32_t compressed_len;
+            unsigned char *payload;
+            STATSCOUNTER_INC(statsCounter.ctrCompressedFrames, statsCounter.mutCtrCompressedFrames);
+            CHKiRet(sessionRead(sess, (unsigned char *)&net32, sizeof(net32)));
+            compressed_len = ntohl(net32);
+            CHKmalloc(payload = malloc(compressed_len));
+            CHKiRet(sessionRead(sess, payload, compressed_len));
+            iRet = lj_parse_compressed_frames(batch, payload, compressed_len);
+            free(payload);
+            CHKiRet(iRet);
+        } else {
+            ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+        }
+    }
+
+    for (idx = 0; idx < batch->count; ++idx) {
+        const uint32_t expected = (uint32_t)idx + 1;
+        if (batch->events[idx].seq != expected) {
+            ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+        }
+    }
+    STATSCOUNTER_ADD(statsCounter.ctrEventsReceived, statsCounter.mutCtrEventsReceived, batch->count);
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal ackBatch(session_t *const sess, const uint32_t seq) {
+    unsigned char ack[6];
+    uint32_t netseq = htonl(seq);
+    rsRetVal iRet;
+
+    ack[0] = LJ_VERSION_V2;
+    ack[1] = LJ_FRAME_ACK;
+    memcpy(ack + 2, &netseq, sizeof(netseq));
+    iRet = sessionSendAll(sess, ack, sizeof(ack));
+    if (iRet == RS_RET_OK) {
+        STATSCOUNTER_INC(statsCounter.ctrBatchesAcked, statsCounter.mutCtrBatchesAcked);
+    } else {
+        STATSCOUNTER_INC(statsCounter.ctrAckFailures, statsCounter.mutCtrAckFailures);
+    }
+    return iRet;
+}
+
+static void unlinkSession(instanceConf_t *const inst, session_t *const target) {
+    session_t **pp;
+    assert(inst != NULL);
+    assert(target != NULL);
+    pthread_mutex_lock(&inst->mutSessions);
+    for (pp = &inst->sessions; *pp != NULL; pp = &(*pp)->next) {
+        if (*pp == target) {
+            *pp = target->next;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&inst->mutSessions);
+}
+
+static void destroySession(session_t *sess) {
+    if (sess == NULL) {
+        return;
+    }
+    if (sess->pStrm != NULL) {
+        netstrm.Destruct(&sess->pStrm);
+    }
+    if (sess->fromHostIP != NULL) {
+        prop.Destruct(&sess->fromHostIP);
+    }
+    if (sess->fromHost != NULL) {
+        prop.Destruct(&sess->fromHost);
+    }
+    if (sess->fromHostPort != NULL) {
+        prop.Destruct(&sess->fromHostPort);
+    }
+    free(sess->fromHostFQDN);
+    free(sess);
+}
+
+static void *sessionThread(void *arg) {
+    session_t *const sess = (session_t *)arg;
+    rsRetVal iRet = RS_RET_OK;
+
+    assert(sess != NULL);
+
+    while (glbl.GetGlobalInputTermState() == 0) {
+        struct lj_batch_s batch;
+        size_t idx;
+
+        memset(&batch, 0, sizeof(batch));
+        iRet = receiveBatch(sess, &batch);
+        if (iRet != RS_RET_OK) {
+            if (iRet == RS_RET_INVALID_VALUE) {
+                STATSCOUNTER_INC(statsCounter.ctrProtocolErrors, statsCounter.mutCtrProtocolErrors);
+            }
+            lj_batch_free(&batch);
+            break;
+        }
+
+        for (idx = 0; idx < batch.count; ++idx) {
+            iRet = submitEvent(sess, &batch.events[idx]);
+            if (iRet != RS_RET_OK) {
+                break;
+            }
+        }
+        if (iRet == RS_RET_OK) {
+            iRet = ackBatch(sess, batch.events[batch.count - 1].seq);
+        }
+        lj_batch_free(&batch);
+        if (iRet != RS_RET_OK) {
+            break;
+        }
+    }
+
+    STATSCOUNTER_INC(statsCounter.ctrConnectionsClosed, statsCounter.mutCtrConnectionsClosed);
+    unlinkSession(sess->inst, sess);
+    destroySession(sess);
+    return NULL;
+}
+
+static rsRetVal spawnSession(instanceConf_t *const inst, netstrm_t *const pNewStrm) {
+    session_t *sess = NULL;
+    struct sockaddr_storage *addr = NULL;
+    DEFiRet;
+
+    CHKmalloc(sess = calloc(1, sizeof(*sess)));
+    sess->inst = inst;
+    sess->pStrm = pNewStrm;
+    CHKiRet(netstrm.GetSock(pNewStrm, &sess->sock));
+    if (inst->bKeepAlive) {
+        CHKiRet(netstrm.SetKeepAliveProbes(pNewStrm, inst->iKeepAliveProbes));
+        CHKiRet(netstrm.SetKeepAliveTime(pNewStrm, inst->iKeepAliveTime));
+        CHKiRet(netstrm.SetKeepAliveIntvl(pNewStrm, inst->iKeepAliveIntvl));
+        CHKiRet(netstrm.EnableKeepAlive(pNewStrm));
+    }
+    if (inst->gnutlsPriorityString != NULL) {
+        CHKiRet(netstrm.SetGnutlsPriorityString(pNewStrm, inst->gnutlsPriorityString));
+    }
+    CHKiRet(netstrm.GetRemoteHName(pNewStrm, &sess->fromHostFQDN));
+    if (sess->fromHostFQDN != NULL) {
+        CHKiRet(prop.Construct(&sess->fromHost));
+        CHKiRet(prop.SetString(sess->fromHost, sess->fromHostFQDN, ustrlen(sess->fromHostFQDN)));
+        CHKiRet(prop.ConstructFinalize(sess->fromHost));
+    }
+    CHKiRet(netstrm.GetRemoteIP(pNewStrm, &sess->fromHostIP));
+    CHKiRet(netstrm.GetRemAddr(pNewStrm, &addr));
+    CHKiRet(createPortProp(addr, &sess->fromHostPort));
+
+    pthread_mutex_lock(&inst->mutSessions);
+    sess->next = inst->sessions;
+    inst->sessions = sess;
+    pthread_mutex_unlock(&inst->mutSessions);
+
+    STATSCOUNTER_INC(statsCounter.ctrConnectionsAccepted, statsCounter.mutCtrConnectionsAccepted);
+    if (pthread_create(&sess->tid, NULL, sessionThread, sess) != 0) {
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    pthread_detach(sess->tid);
+    sess = NULL;
+
+finalize_it:
+    if (iRet != RS_RET_OK && sess != NULL) {
+        destroySession(sess);
+    }
+    RETiRet;
+}
+
+static void *listenerThread(void *arg) {
+    instanceConf_t *const inst = (instanceConf_t *)arg;
+    struct pollfd *pfds = NULL;
+    size_t i;
+
+    assert(inst != NULL);
+    pfds = calloc(inst->listener_count, sizeof(struct pollfd));
+    if (pfds == NULL) {
+        return NULL;
+    }
+    for (i = 0; i < inst->listener_count; ++i) {
+        pfds[i].fd = inst->listener_socks[i];
+        pfds[i].events = POLLIN;
+    }
+
+    inst->listener_running = 1;
+    while (glbl.GetGlobalInputTermState() == 0) {
+        if (poll(pfds, inst->listener_count, 1000) <= 0) {
+            continue;
+        }
+        for (i = 0; i < inst->listener_count; ++i) {
+            if ((pfds[i].revents & POLLIN) != 0) {
+                netstrm_t *pNewStrm = NULL;
+                char connInfo[TCPSRV_CONNINFO_SIZE];
+                rsRetVal iRet;
+
+                memset(connInfo, 0, sizeof(connInfo));
+                iRet = netstrm.AcceptConnReq(inst->listeners[i], &pNewStrm, connInfo);
+                if (iRet == RS_RET_OK) {
+                    iRet = spawnSession(inst, pNewStrm);
+                    if (iRet != RS_RET_OK && pNewStrm != NULL) {
+                        netstrm.Destruct(&pNewStrm);
+                    }
+                }
+            }
+        }
+    }
+
+    free(pfds);
+    return NULL;
+}
+
+static rsRetVal destroyInstanceRuntime(instanceConf_t *inst) {
+    size_t i;
+
+    if (inst->listener_running) {
+        pthread_join(inst->listener_tid, NULL);
+        inst->listener_running = 0;
+    }
+
+    for (i = 0; i < inst->listener_count; ++i) {
+        if (inst->listeners[i] != NULL) {
+            netstrm.Destruct(&inst->listeners[i]);
+        }
+    }
+    free(inst->listeners);
+    inst->listeners = NULL;
+    free(inst->listener_socks);
+    inst->listener_socks = NULL;
+    inst->listener_count = 0;
+    inst->listener_cap = 0;
+    if (inst->pNS != NULL) {
+        netstrms.Destruct(&inst->pNS);
+    }
+    return RS_RET_OK;
+}
+
+static rsRetVal createInstance(instanceConf_t **const pinst) {
+    instanceConf_t *inst;
+    DEFiRet;
+
+    CHKmalloc(inst = calloc(1, sizeof(*inst)));
+    pthread_mutex_init(&inst->mutSessions, NULL);
+    inst->iStrmDrvrMode = 0;
+    if (loadModConf->tail == NULL) {
+        loadModConf->root = loadModConf->tail = inst;
+    } else {
+        loadModConf->tail->next = inst;
+        loadModConf->tail = inst;
+    }
+    *pinst = inst;
+
+finalize_it:
+    RETiRet;
+}
+
+BEGINnewInpInst
+    struct cnfparamvals *pvals;
+    instanceConf_t *inst = NULL;
+    int i;
+    CODESTARTnewInpInst;
+    pvals = nvlstGetParams(lst, &inppblk, NULL);
+    if (pvals == NULL) {
+        ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
+    }
+    CHKiRet(createInstance(&inst));
+    for (i = 0; i < inppblk.nParams; ++i) {
+        int j;
+        if (!pvals[i].bUsed) continue;
+        if (!strcmp(inppblk.descr[i].name, "port")) {
+            inst->port = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+        } else if (!strcmp(inppblk.descr[i].name, "address")) {
+            inst->address = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+        } else if (!strcmp(inppblk.descr[i].name, "ruleset")) {
+            inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+        } else if (!strcmp(inppblk.descr[i].name, "name")) {
+            inst->pszInputName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+        } else if (!strcmp(inppblk.descr[i].name, "listenportfilename")) {
+            inst->pszLstnPortFileName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+        } else if (!strcmp(inppblk.descr[i].name, "networknamespace")) {
+            inst->pszNetworkNamespace = es_str2cstr(pvals[i].val.d.estr, NULL);
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.name")) {
+            inst->pszStrmDrvrName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.mode")) {
+            inst->iStrmDrvrMode = (int)pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.authmode")) {
+            inst->pszStrmDrvrAuthMode = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.permitexpiredcerts")) {
+            inst->pszStrmDrvrPermitExpiredCerts = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.cafile")) {
+            inst->pszStrmDrvrCAFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.crlfile")) {
+            inst->pszStrmDrvrCRLFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.keyfile")) {
+            inst->pszStrmDrvrKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.certfile")) {
+            inst->pszStrmDrvrCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.checkextendedkeypurpose")) {
+            inst->iStrmDrvrExtendedCertCheck = (int)pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.prioritizesan")) {
+            inst->iStrmDrvrSANPreference = (int)pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.tlsverifydepth")) {
+            inst->iStrmTlsVerifyDepth = (int)pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.tlsrevocationcheck")) {
+            inst->iStrmTlsRevocationCheck = (int)pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "permittedpeer")) {
+            for (j = 0; j < pvals[i].val.d.ar->nmemb; ++j) {
+                uchar *const peer = (uchar *)es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);
+                CHKiRet(net.AddPermittedPeer(&inst->pPermPeersRoot, peer));
+                free(peer);
+            }
+        } else if (!strcmp(inppblk.descr[i].name, "keepalive")) {
+            inst->bKeepAlive = (int)pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "keepalive.probes")) {
+            inst->iKeepAliveProbes = (int)pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "keepalive.time")) {
+            inst->iKeepAliveTime = (int)pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "keepalive.interval")) {
+            inst->iKeepAliveIntvl = (int)pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "gnutlsprioritystring")) {
+            inst->gnutlsPriorityString = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+        }
+    }
+    if (inst->pszInputName != NULL) {
+        CHKiRet(prop.Construct(&inst->pInputName));
+        CHKiRet(prop.SetString(inst->pInputName, inst->pszInputName, ustrlen(inst->pszInputName)));
+        CHKiRet(prop.ConstructFinalize(inst->pInputName));
+    }
+
+finalize_it:
+    CODE_STD_FINALIZERnewInpInst if (pvals != NULL) cnfparamvalsDestruct(pvals, &inppblk);
+ENDnewInpInst
+
+BEGINbeginCnfLoad
+    CODESTARTbeginCnfLoad;
+    loadModConf = pModConf;
+    pModConf->pConf = pConf;
+ENDbeginCnfLoad
+
+BEGINsetModCnf
+    struct cnfparamvals *pvals = NULL;
+    CODESTARTsetModCnf;
+    pvals = nvlstGetParams(lst, &modpblk, NULL);
+    if (pvals != NULL) cnfparamvalsDestruct(pvals, &modpblk);
+ENDsetModCnf
+
+BEGINendCnfLoad
+    CODESTARTendCnfLoad;
+    loadModConf = NULL;
+ENDendCnfLoad
+
+BEGINcheckCnf
+    instanceConf_t *inst;
+    CODESTARTcheckCnf;
+    for (inst = pModConf->root; inst != NULL; inst = inst->next) {
+        std_checkRuleset(pModConf, inst);
+    }
+ENDcheckCnf
+
+BEGINactivateCnfPrePrivDrop
+    CODESTARTactivateCnfPrePrivDrop;
+    runModConf = pModConf;
+ENDactivateCnfPrePrivDrop
+
+BEGINactivateCnf
+    instanceConf_t *inst;
+    CODESTARTactivateCnf;
+    for (inst = pModConf->root; inst != NULL; inst = inst->next) {
+        if (inst->pszBindRuleset != NULL) {
+            const rsRetVal localRet = ruleset.GetRuleset(pModConf->pConf, &inst->pBindRuleset, inst->pszBindRuleset);
+            if (localRet != RS_RET_OK) {
+                iRet = localRet;
+                break;
+            }
+        }
+    }
+ENDactivateCnf
+
+BEGINfreeCnf
+    instanceConf_t *inst, *del;
+    CODESTARTfreeCnf;
+    for (inst = pModConf->root; inst != NULL;) {
+        del = inst;
+        inst = inst->next;
+        destroyInstanceRuntime(del);
+        free(del->port);
+        free(del->address);
+        free(del->pszBindRuleset);
+        free(del->pszInputName);
+        free(del->pszLstnPortFileName);
+        free(del->pszNetworkNamespace);
+        free(del->pszStrmDrvrName);
+        free(del->pszStrmDrvrAuthMode);
+        free(del->pszStrmDrvrPermitExpiredCerts);
+        free(del->pszStrmDrvrCAFile);
+        free(del->pszStrmDrvrCRLFile);
+        free(del->pszStrmDrvrKeyFile);
+        free(del->pszStrmDrvrCertFile);
+        free(del->gnutlsPriorityString);
+        if (del->pPermPeersRoot != NULL) {
+            net.DestructPermittedPeers(&del->pPermPeersRoot);
+        }
+        if (del->pInputName != NULL) {
+            prop.Destruct(&del->pInputName);
+        }
+        pthread_mutex_destroy(&del->mutSessions);
+        free(del);
+    }
+ENDfreeCnf
+
+BEGINrunInput
+    instanceConf_t *inst;
+    CODESTARTrunInput;
+    for (inst = runModConf->root; inst != NULL; inst = inst->next) {
+        CHKiRet(buildListeners(inst));
+        if (pthread_create(&inst->listener_tid, NULL, listenerThread, inst) != 0) {
+            ABORT_FINALIZE(RS_RET_IO_ERROR);
+        }
+    }
+    while (glbl.GetGlobalInputTermState() == 0) {
+        srSleep(0, 250000);
+    }
+    for (inst = runModConf->root; inst != NULL; inst = inst->next) {
+        destroyInstanceRuntime(inst);
+    }
+finalize_it:
+ENDrunInput
+
+BEGINwillRun
+    CODESTARTwillRun;
+ENDwillRun
+
+BEGINafterRun
+    CODESTARTafterRun;
+ENDafterRun
+
+BEGINmodExit
+    CODESTARTmodExit;
+    if (pInputName != NULL) {
+        prop.Destruct(&pInputName);
+    }
+    if (statsCounter.stats != NULL) {
+        statsobj.Destruct(&statsCounter.stats);
+    }
+    objRelease(statsobj, CORE_COMPONENT);
+    objRelease(glbl, CORE_COMPONENT);
+    objRelease(net, LM_NET_FILENAME);
+    objRelease(netstrm, LM_NETSTRMS_FILENAME);
+    objRelease(netstrms, LM_NETSTRMS_FILENAME);
+    objRelease(prop, CORE_COMPONENT);
+    objRelease(ruleset, CORE_COMPONENT);
+ENDmodExit
+
+BEGINisCompatibleWithFeature
+    CODESTARTisCompatibleWithFeature;
+    if (eFeat == sFEATURENonCancelInputTermination) iRet = RS_RET_OK;
+ENDisCompatibleWithFeature
+
+BEGINqueryEtryPt
+    CODESTARTqueryEtryPt;
+    CODEqueryEtryPt_STD_IMOD_QUERIES;
+    CODEqueryEtryPt_STD_CONF2_QUERIES;
+    CODEqueryEtryPt_STD_CONF2_setModCnf_QUERIES;
+    CODEqueryEtryPt_STD_CONF2_PREPRIVDROP_QUERIES;
+    CODEqueryEtryPt_STD_CONF2_IMOD_QUERIES;
+    CODEqueryEtryPt_IsCompatibleWithFeature_IF_OMOD_QUERIES;
+ENDqueryEtryPt
+
+BEGINmodInit()
+    CODESTARTmodInit;
+    *ipIFVersProvided = CURR_MOD_IF_VERSION;
+    CODEmodInit_QueryRegCFSLineHdlr;
+    CHKiRet(objUse(glbl, CORE_COMPONENT));
+    CHKiRet(objUse(net, LM_NET_FILENAME));
+    CHKiRet(objUse(netstrm, LM_NETSTRMS_FILENAME));
+    CHKiRet(objUse(netstrms, LM_NETSTRMS_FILENAME));
+    CHKiRet(objUse(prop, CORE_COMPONENT));
+    CHKiRet(objUse(ruleset, CORE_COMPONENT));
+    CHKiRet(objUse(statsobj, CORE_COMPONENT));
+
+    CHKiRet(prop.Construct(&pInputName));
+    CHKiRet(prop.SetString(pInputName, UCHAR_CONSTANT("imbeats"), sizeof("imbeats") - 1));
+    CHKiRet(prop.ConstructFinalize(pInputName));
+
+    CHKiRet(statsobj.Construct(&statsCounter.stats));
+    CHKiRet(statsobj.SetName(statsCounter.stats, UCHAR_CONSTANT("imbeats")));
+    CHKiRet(statsobj.SetOrigin(statsCounter.stats, UCHAR_CONSTANT("imbeats")));
+    STATSCOUNTER_INIT(statsCounter.ctrConnectionsAccepted, statsCounter.mutCtrConnectionsAccepted);
+    STATSCOUNTER_INIT(statsCounter.ctrConnectionsClosed, statsCounter.mutCtrConnectionsClosed);
+    STATSCOUNTER_INIT(statsCounter.ctrProtocolErrors, statsCounter.mutCtrProtocolErrors);
+    STATSCOUNTER_INIT(statsCounter.ctrBatchesReceived, statsCounter.mutCtrBatchesReceived);
+    STATSCOUNTER_INIT(statsCounter.ctrBatchesAcked, statsCounter.mutCtrBatchesAcked);
+    STATSCOUNTER_INIT(statsCounter.ctrEventsReceived, statsCounter.mutCtrEventsReceived);
+    STATSCOUNTER_INIT(statsCounter.ctrEventsSubmitted, statsCounter.mutCtrEventsSubmitted);
+    STATSCOUNTER_INIT(statsCounter.ctrEventsFailed, statsCounter.mutCtrEventsFailed);
+    STATSCOUNTER_INIT(statsCounter.ctrCompressedFrames, statsCounter.mutCtrCompressedFrames);
+    STATSCOUNTER_INIT(statsCounter.ctrJsonDecodeFailures, statsCounter.mutCtrJsonDecodeFailures);
+    STATSCOUNTER_INIT(statsCounter.ctrAckFailures, statsCounter.mutCtrAckFailures);
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("connections.accepted"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrConnectionsAccepted));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("connections.closed"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrConnectionsClosed));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("protocol_errors"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrProtocolErrors));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("batches.received"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrBatchesReceived));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("batches.acked"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrBatchesAcked));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("events.received"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrEventsReceived));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("events.submitted"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrEventsSubmitted));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("events.failed"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrEventsFailed));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("compressed_frames"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrCompressedFrames));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("json_decode_failures"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrJsonDecodeFailures));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("ack_failures"), ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &statsCounter.ctrAckFailures));
+    CHKiRet(statsobj.ConstructFinalize(statsCounter.stats));
+ENDmodInit

--- a/plugins/imbeats/lj_parser.c
+++ b/plugins/imbeats/lj_parser.c
@@ -1,0 +1,179 @@
+/*
+ * Minimal Lumberjack v2 parser helpers for imbeats.
+ *
+ * This layer deliberately stays transport-agnostic. Network reads, ACK timing,
+ * and rsyslog message construction live in imbeats.c.
+ */
+#include "config.h"
+#include "lj_parser.h"
+
+#include <arpa/inet.h>
+#include <string.h>
+#include <stdlib.h>
+#include <zlib.h>
+
+static rsRetVal append_event_owned(struct lj_batch_s *batch, uint32_t seq, unsigned char *payload, size_t payload_len) {
+    if (batch == NULL || batch->events == NULL || batch->count >= batch->window_size) {
+        free(payload);
+        return RS_RET_PARAM_ERROR;
+    }
+
+    batch->events[batch->count].seq = seq;
+    batch->events[batch->count].payload = payload;
+    batch->events[batch->count].payload_len = payload_len;
+    ++batch->count;
+    return RS_RET_OK;
+}
+
+rsRetVal lj_batch_alloc(struct lj_batch_s *batch, uint32_t window_size) {
+    if (batch == NULL || window_size == 0) {
+        return RS_RET_PARAM_ERROR;
+    }
+    memset(batch, 0, sizeof(*batch));
+    batch->window_size = window_size;
+    batch->events = calloc(window_size, sizeof(struct lj_event_s));
+    return (batch->events == NULL) ? RS_RET_OUT_OF_MEMORY : RS_RET_OK;
+}
+
+void lj_batch_free(struct lj_batch_s *batch) {
+    size_t i;
+    if (batch == NULL) {
+        return;
+    }
+    for (i = 0; i < batch->count; ++i) {
+        free(batch->events[i].payload);
+    }
+    free(batch->events);
+    memset(batch, 0, sizeof(*batch));
+}
+
+rsRetVal lj_parse_window_header(const unsigned char hdr[2], uint32_t window_size) {
+    if (hdr[0] != LJ_VERSION_V2 || hdr[1] != LJ_FRAME_WINDOW || window_size == 0) {
+        return RS_RET_INVALID_VALUE;
+    }
+    return RS_RET_OK;
+}
+
+rsRetVal lj_append_json_event(struct lj_batch_s *batch,
+                              uint32_t seq,
+                              const unsigned char *payload,
+                              size_t payload_len) {
+    unsigned char *cpy;
+    if (batch == NULL || payload == NULL || payload_len == 0) {
+        return RS_RET_PARAM_ERROR;
+    }
+    cpy = malloc(payload_len + 1);
+    if (cpy == NULL) {
+        return RS_RET_OUT_OF_MEMORY;
+    }
+    memcpy(cpy, payload, payload_len);
+    cpy[payload_len] = '\0';
+    return append_event_owned(batch, seq, cpy, payload_len);
+}
+
+static rsRetVal parse_frames_from_memory(struct lj_batch_s *batch, const unsigned char *buf, size_t len) {
+    size_t off = 0;
+
+    while (off + 2 <= len) {
+        const unsigned char ver = buf[off++];
+        const unsigned char type = buf[off++];
+        uint32_t v1, v2;
+        rsRetVal iRet;
+
+        if (ver != LJ_VERSION_V2) {
+            return RS_RET_INVALID_VALUE;
+        }
+
+        switch (type) {
+            case LJ_FRAME_JSON:
+                if (off + 8 > len) {
+                    return RS_RET_INVALID_VALUE;
+                }
+                memcpy(&v1, buf + off, 4);
+                memcpy(&v2, buf + off + 4, 4);
+                off += 8;
+                v1 = ntohl(v1);
+                v2 = ntohl(v2);
+                if (off + v2 > len) {
+                    return RS_RET_INVALID_VALUE;
+                }
+                iRet = lj_append_json_event(batch, v1, buf + off, v2);
+                if (iRet != RS_RET_OK) {
+                    return iRet;
+                }
+                off += v2;
+                break;
+            case LJ_FRAME_COMPRESSED:
+                if (off + 4 > len) {
+                    return RS_RET_INVALID_VALUE;
+                }
+                memcpy(&v1, buf + off, 4);
+                off += 4;
+                v1 = ntohl(v1);
+                if (off + v1 > len) {
+                    return RS_RET_INVALID_VALUE;
+                }
+                iRet = lj_parse_compressed_frames(batch, buf + off, v1);
+                if (iRet != RS_RET_OK) {
+                    return iRet;
+                }
+                off += v1;
+                break;
+            default:
+                return RS_RET_INVALID_VALUE;
+        }
+    }
+
+    return (off == len) ? RS_RET_OK : RS_RET_INVALID_VALUE;
+}
+
+rsRetVal lj_parse_compressed_frames(struct lj_batch_s *batch, const unsigned char *payload, size_t payload_len) {
+    z_stream zstrm;
+    unsigned char *out = NULL;
+    size_t out_cap = 0;
+    size_t out_len = 0;
+    int zrc;
+    rsRetVal iRet = RS_RET_OK;
+
+    if (batch == NULL || payload == NULL || payload_len == 0) {
+        return RS_RET_PARAM_ERROR;
+    }
+
+    memset(&zstrm, 0, sizeof(zstrm));
+    zstrm.next_in = (Bytef *)payload;
+    zstrm.avail_in = payload_len;
+
+    zrc = inflateInit(&zstrm);
+    if (zrc != Z_OK) {
+        return RS_RET_ZLIB_ERR;
+    }
+
+    do {
+        if (out_len == out_cap) {
+            size_t new_cap = (out_cap == 0) ? 4096 : out_cap * 2;
+            unsigned char *tmp = realloc(out, new_cap);
+            if (tmp == NULL) {
+                iRet = RS_RET_OUT_OF_MEMORY;
+                goto finalize_it;
+            }
+            out = tmp;
+            out_cap = new_cap;
+        }
+
+        zstrm.next_out = out + out_len;
+        zstrm.avail_out = out_cap - out_len;
+        zrc = inflate(&zstrm, Z_NO_FLUSH);
+        out_len = out_cap - zstrm.avail_out;
+        if (zrc != Z_OK && zrc != Z_STREAM_END) {
+            iRet = RS_RET_ZLIB_ERR;
+            goto finalize_it;
+        }
+    } while (zrc != Z_STREAM_END);
+
+    iRet = parse_frames_from_memory(batch, out, out_len);
+
+finalize_it:
+    inflateEnd(&zstrm);
+    free(out);
+    return iRet;
+}

--- a/plugins/imbeats/lj_parser.h
+++ b/plugins/imbeats/lj_parser.h
@@ -1,0 +1,33 @@
+#ifndef IMBEATS_LJ_PARSER_H
+#define IMBEATS_LJ_PARSER_H
+
+#include "config.h"
+#include <stddef.h>
+#include <stdint.h>
+#include "rsyslog.h"
+
+#define LJ_VERSION_V2 ((unsigned char)'2')
+#define LJ_FRAME_WINDOW ((unsigned char)'W')
+#define LJ_FRAME_JSON ((unsigned char)'J')
+#define LJ_FRAME_COMPRESSED ((unsigned char)'C')
+#define LJ_FRAME_ACK ((unsigned char)'A')
+
+struct lj_event_s {
+    uint32_t seq;
+    unsigned char *payload;
+    size_t payload_len;
+};
+
+struct lj_batch_s {
+    uint32_t window_size;
+    size_t count;
+    struct lj_event_s *events;
+};
+
+rsRetVal lj_batch_alloc(struct lj_batch_s *batch, uint32_t window_size);
+void lj_batch_free(struct lj_batch_s *batch);
+rsRetVal lj_parse_window_header(const unsigned char hdr[2], uint32_t window_size);
+rsRetVal lj_append_json_event(struct lj_batch_s *batch, uint32_t seq, const unsigned char *payload, size_t payload_len);
+rsRetVal lj_parse_compressed_frames(struct lj_batch_s *batch, const unsigned char *payload, size_t payload_len);
+
+#endif

--- a/scripts/build_repo_policy_focus_input.py
+++ b/scripts/build_repo_policy_focus_input.py
@@ -65,6 +65,11 @@ def file_exists_at_ref(ref: str, path: str) -> bool:
     return result.returncode == 0
 
 
+def list_tree(ref: str, path: str) -> list[str]:
+    output = run_git(["ls-tree", "-r", "--name-only", ref, "--", path], check=False)
+    return [line for line in output.splitlines() if line]
+
+
 def read_file_at_ref(ref: str, path: str) -> str:
     return run_git(["show", f"{ref}:{path}"])
 
@@ -298,13 +303,6 @@ def build_doc_xref_check(name_status: list[dict[str, object]], base: str, head: 
             "relevant_diff": limited_diff(base, head, relevant_paths) if applicable else "",
         },
     }
-
-
-
-    output = run_git(["ls-tree", "-r", "--name-only", ref, "--", path], check=False)
-    return [line for line in output.splitlines() if line]
-
-
 def build_module_check(name_status: list[dict[str, object]], base: str, head: str) -> dict[str, object]:
     # Treat a brand-new plugins/ or contrib/ subtree with code or build files as
     # a module candidate, then check only for deterministic onboarding signals.

--- a/scripts/evaluate_repo_policy_focus.py
+++ b/scripts/evaluate_repo_policy_focus.py
@@ -166,7 +166,7 @@ def evaluate_doc_xref_sync(check: dict[str, object]) -> dict[str, object]:
     }
 
 
-
+def evaluate_module_onboarding(check: dict[str, object]) -> dict[str, object]:
     # Missing metadata is a hard policy failure; missing docs stay advisory
     # until rsyslog has a stricter deterministic doc coverage rule.
     facts = check["facts"]

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1032,6 +1032,12 @@ TESTS_IMHTTP_VALGRIND = \
 	imhttp-post-payload-compress-vg.sh \
 	imhttp-getrequest-file-vg.sh
 
+TESTS_IMBEATS = \
+	imbeats-basic.sh \
+	imbeats-compressed.sh \
+	imbeats-filebeat-docker.sh \
+	yaml-imbeats-basic.sh
+
 TESTS_OMRABBITMQ = \
 	omrabbitmq_no_params.sh \
 	omrabbitmq_params_missing0.sh \
@@ -1866,6 +1872,7 @@ EXTRA_DIST += $(TESTS_IMDOCKER_VALGRIND)
 EXTRA_DIST += $(TESTS_IMCZMQ)
 EXTRA_DIST += $(TESTS_IMHTTP)
 EXTRA_DIST += $(TESTS_IMHTTP_VALGRIND)
+EXTRA_DIST += $(TESTS_IMBEATS)
 EXTRA_DIST += $(TESTS_OMRABBITMQ)
 EXTRA_DIST += $(TESTS_OMRABBITMQ_VALGRIND)
 EXTRA_DIST += $(TESTS_IMHIREDIS)
@@ -2574,6 +2581,12 @@ if HAVE_VALGRIND
 TESTS += $(TESTS_IMHTTP_VALGRIND)
 endif # HAVE_VALGRIND
 endif # ENABLE_IMHTTP
+
+if ENABLE_IMBEATS
+if ENABLE_TESTBENCH
+TESTS += $(TESTS_IMBEATS)
+endif # ENABLE_TESTBENCH
+endif # ENABLE_IMBEATS
 
 
 

--- a/tests/imbeats-basic.sh
+++ b/tests/imbeats-basic.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+require_plugin imbeats
+
+generate_conf
+add_conf '
+module(load="../plugins/imbeats/.libs/imbeats")
+
+template(name="outfmt" type="string"
+         string="%msg%|%$!message%|%$!host!name%|%$!metadata!imbeats!protocol%|%$!metadata!imbeats!sequence%\n")
+
+ruleset(name="main") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+
+input(type="imbeats"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.imbeats.port"
+      ruleset="main")
+'
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
+
+python3 - "$RS_PORT" > "$RSYSLOG_DYNNAME.imbeats.ack" <<'PY'
+import json
+import socket
+import struct
+import sys
+
+port = int(sys.argv[1])
+payload = json.dumps({"message": "hello", "host": {"name": "web01"}}, separators=(",", ":")).encode()
+batch = b"2W" + struct.pack(">I", 1)
+event = b"2J" + struct.pack(">I", 1) + struct.pack(">I", len(payload)) + payload
+
+sock = socket.create_connection(("127.0.0.1", port))
+sock.sendall(batch + event)
+ack = sock.recv(6)
+sys.stdout.write(ack.hex())
+sock.close()
+PY
+
+shutdown_when_empty
+wait_shutdown
+
+EXPECTED='{"message":"hello","host":{"name":"web01"}}|hello|web01|lumberjack-v2|1'
+cmp_exact
+
+test "$(cat "$RSYSLOG_DYNNAME.imbeats.ack")" = "324100000001"
+
+exit_test

--- a/tests/imbeats-compressed.sh
+++ b/tests/imbeats-compressed.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+require_plugin imbeats
+
+generate_conf
+add_conf '
+module(load="../plugins/imbeats/.libs/imbeats")
+
+template(name="outfmt" type="string"
+         string="%msg%|%$!message%|%$!metadata!imbeats!sequence%\n")
+
+ruleset(name="main") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+
+input(type="imbeats"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.imbeats.port"
+      ruleset="main")
+'
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
+
+python3 - "$RS_PORT" > "$RSYSLOG_DYNNAME.imbeats.ack" <<'PY'
+import json
+import socket
+import struct
+import sys
+import zlib
+
+port = int(sys.argv[1])
+payload = json.dumps({"message": "compressed"}, separators=(",", ":")).encode()
+nested = b"2J" + struct.pack(">I", 1) + struct.pack(">I", len(payload)) + payload
+compressed = zlib.compress(nested)
+wire = b"2W" + struct.pack(">I", 1) + b"2C" + struct.pack(">I", len(compressed)) + compressed
+
+sock = socket.create_connection(("127.0.0.1", port))
+sock.sendall(wire)
+ack = sock.recv(6)
+sys.stdout.write(ack.hex())
+sock.close()
+PY
+
+shutdown_when_empty
+wait_shutdown
+
+EXPECTED='{"message":"compressed"}|compressed|1'
+cmp_exact
+
+test "$(cat "$RSYSLOG_DYNNAME.imbeats.ack")" = "324100000001"
+
+exit_test

--- a/tests/imbeats-filebeat-docker.sh
+++ b/tests/imbeats-filebeat-docker.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+check_command_available docker
+
+if ! docker info >/dev/null 2>&1 ; then
+	echo "docker daemon not available, skipping test"
+	exit 77
+fi
+
+export NUMMESSAGES=200
+export SEQ_CHECK_FILE="${TESTTOOL_DIR}/${RSYSLOG_OUT_LOG}"
+export FB_IMAGE="${FB_IMAGE:-docker.elastic.co/beats/filebeat:9.2.0}"
+export FB_CONTAINER="fb-imbeats-${RSYSLOG_DYNNAME}"
+export FB_WORKDIR="${TESTTOOL_DIR}/${RSYSLOG_DYNNAME}.filebeat"
+if [ -z "$FB_DOCKER_MOUNT_SOURCE" ] && [ -n "$GITHUB_WORKSPACE" ] ; then
+	case "$FB_WORKDIR" in
+		/rsyslog/*) FB_DOCKER_MOUNT_SOURCE="${GITHUB_WORKSPACE}${FB_WORKDIR#/rsyslog}" ;;
+	esac
+fi
+export FB_DOCKER_MOUNT_SOURCE="${FB_DOCKER_MOUNT_SOURCE:-$FB_WORKDIR}"
+export FB_INPUT="${FB_WORKDIR}/input.log"
+export FB_CONFIG="${FB_WORKDIR}/filebeat.yml"
+export FB_LOG="${FB_WORKDIR}/docker.log"
+
+cleanup_filebeat() {
+	docker rm -f "$FB_CONTAINER" >/dev/null 2>&1 || true
+	rm -rf "$FB_WORKDIR"
+}
+trap cleanup_filebeat EXIT
+
+mkdir -p "$FB_WORKDIR/data"
+for i in $(seq 0 $((NUMMESSAGES - 1))) ; do
+	printf 'msgnum:%08d:\n' "$i"
+done > "$FB_INPUT"
+
+generate_conf
+add_conf '
+module(load="../plugins/imbeats/.libs/imbeats")
+
+template(name="outfmt" type="string" string="%$!message%\n")
+
+ruleset(name="main") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+
+input(type="imbeats"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.imbeats.port"
+      ruleset="main")
+'
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
+
+cat > "$FB_CONFIG" <<EOF
+filebeat.inputs:
+  - type: filestream
+    id: imbeats-test
+    enabled: true
+    paths:
+      - /work/input.log
+
+output.logstash:
+  hosts: ["127.0.0.1:${RS_PORT}"]
+
+logging.level: info
+logging.to_files: false
+EOF
+
+docker image inspect "$FB_IMAGE" >/dev/null 2>&1 || docker pull "$FB_IMAGE" >/dev/null
+
+docker run -d --rm \
+	--name "$FB_CONTAINER" \
+	--network host \
+	--user root \
+	-v "$FB_DOCKER_MOUNT_SOURCE:/work" \
+	"$FB_IMAGE" \
+	filebeat -e --strict.perms=false -c /work/filebeat.yml > "$FB_LOG"
+
+wait_file_lines "$SEQ_CHECK_FILE" "$NUMMESSAGES"
+
+docker rm -f "$FB_CONTAINER" >/dev/null 2>&1 || true
+
+shutdown_when_empty
+wait_shutdown
+
+cmp "$FB_INPUT" "$SEQ_CHECK_FILE"
+exit_test

--- a/tests/yaml-imbeats-basic.sh
+++ b/tests/yaml-imbeats-basic.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+require_plugin imbeats
+
+generate_conf --yaml-only
+add_yaml_conf 'modules:'
+add_yaml_conf '  - load: "../plugins/imbeats/.libs/imbeats"'
+add_yaml_conf ''
+add_yaml_conf 'templates:'
+add_yaml_conf '  - name: outfmt'
+add_yaml_conf '    type: string'
+add_yaml_conf '    string: "%msg%|%$!message%|%$!metadata!imbeats!sequence%\n"'
+add_yaml_conf ''
+add_yaml_conf 'inputs:'
+add_yaml_imdiag_input
+add_yaml_conf '  - type: imbeats'
+add_yaml_conf '    port: "0"'
+add_yaml_conf "    listenPortFileName: \"${RSYSLOG_DYNNAME}.imbeats.port\""
+add_yaml_conf '    ruleset: main'
+add_yaml_conf ''
+add_yaml_conf 'rulesets:'
+add_yaml_conf '  - name: main'
+add_yaml_conf '    script: |'
+add_yaml_conf "      action(type=\"omfile\" file=\"${RSYSLOG_OUT_LOG}\" template=\"outfmt\")"
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
+
+python3 - "$RS_PORT" <<'PY'
+import json
+import socket
+import struct
+import sys
+
+port = int(sys.argv[1])
+payload = json.dumps({"message": "yaml"}, separators=(",", ":")).encode()
+wire = b"2W" + struct.pack(">I", 1) + b"2J" + struct.pack(">I", 1) + struct.pack(">I", len(payload)) + payload
+
+sock = socket.create_connection(("127.0.0.1", port))
+sock.sendall(wire)
+sock.recv(6)
+sock.close()
+PY
+
+shutdown_when_empty
+wait_shutdown
+
+EXPECTED='{"message":"yaml"}|yaml|1'
+cmp_exact
+
+exit_test


### PR DESCRIPTION
## What changed

This adds a new `imbeats` input module for receiving Elastic Beats traffic
via Lumberjack v2 over plain TCP or TLS.

The change includes:

- a dedicated `plugins/imbeats/` module built on `netstrm`/`netstrms`
- strict Lumberjack v2 handling for `W`, `J`, `C`, and `A` frames
- JSON event decoding with the original payload preserved in `msg`
- Beat fields mapped into the structured event tree
- protocol and transport metadata under `$!metadata!imbeats`
- docs and parameter reference pages
- shell coverage for basic, compressed, YAML, and real Filebeat Docker tests
- a dedicated `run_checks` CI job for the Filebeat integration test

## Why

This provides a native rsyslog ingestion path for Beats-compatible senders
without requiring a Logstash hop.

## Notes

The current event representation is intentionally optimized for common
Elasticsearch-bound flows. The code and module notes document that making
representation configurable remains a deferred follow-up decision.

## Validation

Ran locally:

- `make -C plugins/imbeats -j4`
- `./tests/imbeats-basic.sh`
- `./tests/imbeats-compressed.sh`
- `./tests/yaml-imbeats-basic.sh`
- `./tests/imbeats-filebeat-docker.sh`
- `bash -n tests/imbeats-filebeat-docker.sh`
