### PR TITLE
imhttp: add route-scoped API key authentication

### DIFF
--- a/contrib/imhttp/imhttp.c
+++ b/contrib/imhttp/imhttp.c
@@ -59,7 +59,14 @@ DEFobjCurrIf(glbl) DEFobjCurrIf(prop) DEFobjCurrIf(ruleset) DEFobjCurrIf(statsob
 #define MAX_READ_BUFFER_SIZE 16384
 #define INIT_SCRATCH_BUF_SIZE 4096
 /* General purpose buffer size. */
+/**
+ * Basic-auth credentials are capped at 2 KiB of Base64 text. That is well
+ * above practical user-id/password sizes, yet still small enough to keep the
+ * parser on a fixed stack buffer and to reject oversized headers as hostile.
+ */
 #define IMHTTP_MAX_BUF_LEN (8192)
+#define BASIC_AUTH_MAX_ENCODED 2048
+#define BASIC_AUTH_MAX_DECODED ((BASIC_AUTH_MAX_ENCODED / 4) * 3)
 #define DEFAULT_HEALTH_CHECK_PATH "/healthz"
 #define DEFAULT_PROM_METRICS_PATH "/metrics"
 
@@ -69,11 +76,21 @@ DEFobjCurrIf(glbl) DEFobjCurrIf(prop) DEFobjCurrIf(ruleset) DEFobjCurrIf(statsob
 };
 
 struct auth_s {
-    char workbuf[IMHTTP_MAX_BUF_LEN];
-    char *pworkbuf;
-    size_t workbuf_len;
+    char workbuf[BASIC_AUTH_MAX_DECODED + 1];
     char *pszUser;
     char *pszPasswd;
+    const char *pszApiKey;
+};
+
+/**
+ * Route auth settings are borrowed from the finalized module config.
+ *
+ * CivetWeb handlers only keep references because the config lifetime covers
+ * the full server lifetime.
+ */
+struct route_auth_ctx_s {
+    const char *pszBasicAuthFile;
+    const char *pszApiKeyFile;
 };
 
 struct data_parse_s {
@@ -101,6 +118,10 @@ struct modConfData_s {
     char *pszMetricsPath;
     char *pszHealthCheckAuthFile;
     char *pszMetricsAuthFile;
+    char *pszHealthCheckApiKeyFile;
+    char *pszMetricsApiKeyFile;
+    struct route_auth_ctx_s healthCheckAuthCtx;
+    struct route_auth_ctx_s metricsAuthCtx;
 };
 
 struct instanceConf_s {
@@ -108,6 +129,7 @@ struct instanceConf_s {
     uchar *pszBindRuleset; /* name of ruleset to bind to */
     uchar *pszEndpoint; /* endpoint to configure */
     uchar *pszBasicAuthFile; /* file containing basic auth users/pass */
+    uchar *pszApiKeyFile; /* file containing accepted API keys */
     ruleset_t *pBindRuleset; /* ruleset to bind listener to (use system default if unspecified) */
     ratelimit_t *ratelimiter;
     int ratelimitInterval;
@@ -119,6 +141,7 @@ struct instanceConf_s {
     sbool bDisableLFDelim;
     sbool bSuppOctetFram;
     sbool bAddMetadata;
+    struct route_auth_ctx_s authCtx;
 };
 
 struct conn_wrkr_s {
@@ -150,12 +173,15 @@ static struct cnfparamdescr modpdescr[] = {{"ports", eCmdHdlrString, 0},
                                            {"healthcheckpath", eCmdHdlrString, 0},
                                            {"metricspath", eCmdHdlrString, 0},
                                            {"healthcheckbasicauthfile", eCmdHdlrString, 0},
-                                           {"metricsbasicauthfile", eCmdHdlrString, 0}};
+                                           {"metricsbasicauthfile", eCmdHdlrString, 0},
+                                           {"healthcheckapikeyfile", eCmdHdlrString, 0},
+                                           {"metricsapikeyfile", eCmdHdlrString, 0}};
 
 static struct cnfparamblk modpblk = {CNFPARAMBLK_VERSION, sizeof(modpdescr) / sizeof(struct cnfparamdescr), modpdescr};
 
 static struct cnfparamdescr inppdescr[] = {{"endpoint", eCmdHdlrString, 0},
                                            {"basicauthfile", eCmdHdlrString, 0},
+                                           {"apikeyfile", eCmdHdlrString, 0},
                                            {"ruleset", eCmdHdlrString, 0},
                                            {"flowcontrol", eCmdHdlrBinary, 0},
                                            {"disablelfdelimiter", eCmdHdlrBinary, 0},
@@ -208,6 +234,40 @@ static rsRetVal processData(const instanceConf_t *const inst,
                             const char *buf,
                             size_t len);
 
+/**
+ * Install borrowed auth sources for a route.
+ *
+ * @param authCtx route-local auth state to populate
+ * @param basicAuthFile borrowed htpasswd path, or NULL
+ * @param apiKeyFile borrowed API-key file path, or NULL
+ *
+ * @note The pointers are borrowed from the module config and must outlive the
+ *       request handler registration.
+ */
+static void routeAuthCtxSet(struct route_auth_ctx_s *const authCtx,
+                            const char *const basicAuthFile,
+                            const char *const apiKeyFile) {
+    if (authCtx == NULL) {
+        return;
+    }
+
+    authCtx->pszBasicAuthFile = basicAuthFile;
+    authCtx->pszApiKeyFile = apiKeyFile;
+}
+
+/**
+ * Check whether a route needs auth handling.
+ *
+ * @param authCtx route-local auth state
+ * @return non-zero if Basic auth or API-key auth is configured
+ *
+ * @note Public routes skip auth handler registration entirely so the request
+ *       path stays on the fast path.
+ */
+static sbool routeAuthConfigured(const struct route_auth_ctx_s *const authCtx) {
+    return authCtx != NULL && (authCtx->pszBasicAuthFile != NULL || authCtx->pszApiKeyFile != NULL);
+}
+
 static rsRetVal createInstance(instanceConf_t **pinst) {
     instanceConf_t *inst;
     DEFiRet;
@@ -217,6 +277,7 @@ static rsRetVal createInstance(instanceConf_t **pinst) {
     inst->pBindRuleset = NULL;
     inst->pszEndpoint = NULL;
     inst->pszBasicAuthFile = NULL;
+    inst->pszApiKeyFile = NULL;
     inst->ratelimiter = NULL;
     inst->pszInputName = NULL;
     inst->pInputName = NULL;
@@ -308,6 +369,8 @@ static void *init_thread(ATTR_UNUSED const struct mg_context *ctx, int thread_ty
 
 finalize_it:
     if (iRet != RS_RET_OK) {
+        free(data != NULL ? data->pReadBuf : NULL);
+        free(data != NULL ? data->pMsg : NULL);
         free(data);
         return NULL;
     }
@@ -342,10 +405,11 @@ static rsRetVal msgAddMetadataFromHttpHeader(smsg_t *const __restrict__ pMsg, st
         CHKmalloc(jval);
         /* truncate header names bigger than INIT_SCRATCH_BUF_SIZE */
         strncpy(connWrkr->pScratchBuf, ri->http_headers[i].name, connWrkr->scratchBufSize - 1);
+        connWrkr->pScratchBuf[connWrkr->scratchBufSize - 1] = '\0';
         /* make header lowercase */
         char *pname = connWrkr->pScratchBuf;
         while (pname && *pname != '\0') {
-            *pname = tolower(*pname);
+            *pname = tolower((unsigned char)*pname);
             pname++;
         }
         json_object_object_add(json, (const char *const)connWrkr->pScratchBuf, jval);
@@ -366,6 +430,7 @@ static rsRetVal msgAddMetadataFromHttpQueryParams(smsg_t *const __restrict__ pMs
 
     if (ri && ri->query_string) {
         strncpy(connWrkr->pScratchBuf, ri->query_string, connWrkr->scratchBufSize - 1);
+        connWrkr->pScratchBuf[connWrkr->scratchBufSize - 1] = '\0';
         char *pquery_str = connWrkr->pScratchBuf;
         if (pquery_str) {
             CHKmalloc(json = json_object_new_object());
@@ -378,7 +443,7 @@ static rsRetVal msgAddMetadataFromHttpQueryParams(smsg_t *const __restrict__ pMs
                 char *key = strtok_r(kv_pair, "=", &saveptr2);
                 if (key) {
                     char *value = strtok_r(NULL, "=", &saveptr2);
-                    struct json_object *const jval = json_object_new_string(value);
+                    struct json_object *const jval = json_object_new_string(value != NULL ? value : "");
                     CHKmalloc(jval);
                     json_object_object_add(json, (const char *)key, jval);
                 }
@@ -397,7 +462,7 @@ static rsRetVal doSubmitMsg(const instanceConf_t *const __restrict__ inst,
                             struct conn_wrkr_s *connWrkr,
                             const uchar *msg,
                             size_t len) {
-    smsg_t *pMsg;
+    smsg_t *pMsg = NULL;
     DEFiRet;
 
     assert(len <= s_iMaxLine);
@@ -429,11 +494,14 @@ static rsRetVal doSubmitMsg(const instanceConf_t *const __restrict__ inst,
         CHKiRet(msgAddMetadataFromHttpQueryParams(pMsg, connWrkr));
     }
 
-    ratelimitAddMsg(inst->ratelimiter, &connWrkr->multiSub, pMsg);
+    CHKiRet(ratelimitAddMsg(inst->ratelimiter, &connWrkr->multiSub, pMsg));
     STATSCOUNTER_INC(statsCounter.ctrSubmitted, statsCounter.mutCtrSubmitted);
 finalize_it:
     connWrkr->iMsg = 0;
     if (iRet != RS_RET_OK) {
+        if (pMsg != NULL && iRet != RS_RET_DISCARDMSG) {
+            msgDestruct(&pMsg);
+        }
         STATSCOUNTER_INC(statsCounter.ctrDiscarded, statsCounter.mutCtrDiscarded);
     }
     RETiRet;
@@ -686,8 +754,24 @@ static rsRetVal processData(const instanceConf_t *const inst,
     RETiRet;
 }
 
-/* Return 1 on success. Always initializes the auth structure. */
-static int parse_auth_header(struct mg_connection *conn, struct auth_s *auth) {
+static const char *skipWhitespace(const char *str) {
+    while (str != NULL && isspace((unsigned char)*str)) {
+        ++str;
+    }
+    return str;
+}
+
+/**
+ * Parse a Basic-auth header into the reusable auth scratch state.
+ *
+ * @param conn CivetWeb request connection
+ * @param auth caller-owned auth scratch state
+ * @return non-zero when the header was present and decodes to user:password
+ *
+ * @note The decoded buffer is reused across calls so the parser can avoid
+ *       extra allocations for the common in-buffer case.
+ */
+static sbool parse_basic_auth_header(struct mg_connection *conn, struct auth_s *auth) {
     if (!auth || !conn) {
         return 0;
     }
@@ -697,21 +781,25 @@ static int parse_auth_header(struct mg_connection *conn, struct auth_s *auth) {
         return 0;
     }
 
-    /* Parse authorization header */
     const char *src = auth_header + 6;
-    size_t len = apr_base64_decode_len((const char *)src);
-    auth->pworkbuf = auth->workbuf;
-    if (len > sizeof(auth->workbuf)) {
-        auth->pworkbuf = calloc(0, len);
-        auth->workbuf_len = len;
-    }
-    len = apr_base64_decode(auth->pworkbuf, src);
-    if (len == 0) {
+    size_t encoded_len = strlen(src);
+    if (encoded_len > BASIC_AUTH_MAX_ENCODED) {
+        LogError(0, NO_ERRCODE, "imhttp: rejecting oversized Basic-auth header (%zu bytes, max %d bytes)", encoded_len,
+                 BASIC_AUTH_MAX_ENCODED);
         return 0;
     }
 
+    size_t len = apr_base64_decode(auth->workbuf, src);
+    if (len == 0 || len > BASIC_AUTH_MAX_DECODED) {
+        return 0;
+    }
+    if (memchr(auth->workbuf, '\0', len) != NULL) {
+        return 0;
+    }
+    auth->workbuf[len] = '\0';
+
     char *passwd = NULL, *saveptr = NULL;
-    char *user = strtok_r(auth->pworkbuf, ":", &saveptr);
+    char *user = strtok_r(auth->workbuf, ":", &saveptr);
     if (user) {
         passwd = strtok_r(NULL, ":", &saveptr);
     }
@@ -719,13 +807,50 @@ static int parse_auth_header(struct mg_connection *conn, struct auth_s *auth) {
     auth->pszUser = user;
     auth->pszPasswd = passwd;
 
-    return 1;
+    return (auth->pszUser != NULL && auth->pszPasswd != NULL);
 }
 
-static int read_auth_file(FILE *filep, struct auth_s *auth) {
-    if (!filep) {
+/**
+ * Parse an Elastic-style API-key header from the request.
+ *
+ * @param conn CivetWeb request connection
+ * @param auth parsed auth output
+ * @return non-zero when a usable API key token was found
+ *
+ * @note Accept both Authorization: ApiKey and X-API-Key because Elastic
+ *       agents and intermediaries do not always use the same header form.
+ *       Leading whitespace after the scheme is ignored for robustness.
+ */
+static sbool parse_api_key_header(struct mg_connection *conn, struct auth_s *auth) {
+    if (!auth || !conn) {
         return 0;
     }
+
+    const char *auth_header = mg_get_header(conn, "Authorization");
+    if (auth_header != NULL && strncasecmp(auth_header, "ApiKey ", 7) == 0) {
+        auth->pszApiKey = skipWhitespace(auth_header + 7);
+        return (auth->pszApiKey != NULL && auth->pszApiKey[0] != '\0');
+    }
+
+    auth->pszApiKey = skipWhitespace(mg_get_header(conn, "X-API-Key"));
+    return (auth->pszApiKey != NULL && auth->pszApiKey[0] != '\0');
+}
+
+/**
+ * Validate a Basic-auth credential pair against an htpasswd file.
+ *
+ * @param filep open htpasswd file
+ * @param auth parsed Basic-auth credentials
+ * @return non-zero if the first matching user/password pair validates
+ *
+ * @note Comments and blank lines are ignored so the file can stay human
+ *       maintainable without affecting auth behavior.
+ */
+static sbool read_auth_file(FILE *filep, struct auth_s *auth) {
+    if (filep == NULL || auth == NULL || auth->pszUser == NULL || auth->pszPasswd == NULL) {
+        return 0;
+    }
+
     char workbuf[IMHTTP_MAX_BUF_LEN];
     size_t l = 0;
     char *user;
@@ -734,19 +859,14 @@ static int read_auth_file(FILE *filep, struct auth_s *auth) {
     while (fgets(workbuf, sizeof(workbuf), filep)) {
         l = strnlen(workbuf, sizeof(workbuf));
         while (l > 0) {
-            if (isspace(workbuf[l - 1]) || iscntrl(workbuf[l - 1])) {
-                l--;
-                workbuf[l] = 0;
+            if (isspace((unsigned char)workbuf[l - 1]) || iscntrl((unsigned char)workbuf[l - 1])) {
+                workbuf[--l] = '\0';
             } else {
                 break;
             }
         }
 
-        if (l < 1) {
-            continue;
-        }
-
-        if (workbuf[0] == '#') {
+        if (l < 1 || workbuf[0] == '#') {
             continue;
         }
 
@@ -755,8 +875,7 @@ static int read_auth_file(FILE *filep, struct auth_s *auth) {
         if (!passwd) {
             continue;
         }
-        *passwd = '\0';
-        passwd++;
+        *passwd++ = '\0';
 
         if (!strcasecmp(auth->pszUser, user)) {
             return (apr_password_validate(auth->pszPasswd, passwd) == APR_SUCCESS);
@@ -765,57 +884,211 @@ static int read_auth_file(FILE *filep, struct auth_s *auth) {
     return 0;
 }
 
-/* Authorize against the opened passwords file. Return 1 if authorized. */
-static int authorize(struct mg_connection *conn, FILE *filep) {
-    if (!conn || !filep) {
+/**
+ * Validate an API key against a token file.
+ *
+ * @param filep open token file
+ * @param presentedApiKey key extracted from the request
+ * @return non-zero if the first matching token validates
+ *
+ * @note The file format is deliberately one token per line so the auth path
+ *       stays a simple string compare instead of a parser.
+ */
+static sbool read_api_key_file(FILE *filep, const char *presentedApiKey) {
+    char workbuf[IMHTTP_MAX_BUF_LEN];
+    size_t l = 0;
+
+    if (filep == NULL || presentedApiKey == NULL || presentedApiKey[0] == '\0') {
         return 0;
     }
 
-    struct auth_s auth = {.workbuf_len = 0, .pworkbuf = NULL, .pszUser = NULL, .pszPasswd = NULL};
-    if (!parse_auth_header(conn, &auth)) {
-        return 0;
+    while (fgets(workbuf, sizeof(workbuf), filep)) {
+        l = strnlen(workbuf, sizeof(workbuf));
+        while (l > 0) {
+            if (isspace((unsigned char)workbuf[l - 1]) || iscntrl((unsigned char)workbuf[l - 1])) {
+                workbuf[--l] = '\0';
+            } else {
+                break;
+            }
+        }
+
+        if (l < 1 || workbuf[0] == '#') {
+            continue;
+        }
+
+        if (strcmp(presentedApiKey, workbuf) == 0) {
+            return 1;
+        }
     }
 
-    /* validate against htpasswd file */
-    return read_auth_file(filep, &auth);
+    return 0;
 }
 
-/* Provides Basic Authorization handling that validates against a 'htpasswd' file.
-    see also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization
-*/
-static int basicAuthHandler(struct mg_connection *conn, void *cbdata) {
-    const char *authFile = (const char *)cbdata;
-    char errStr[512];
+/**
+ * Open an auth file and report failures through the rsyslog error path.
+ *
+ * @param conn CivetWeb request connection used for request-scoped logging
+ * @param authFile path to the auth file
+ * @return open FILE handle, or NULL on error
+ *
+ * @note LogError() is used so errno expansion flows through rsyslog's normal
+ *       message formatting instead of hand-formatting strerror strings here.
+ */
+static FILE *openAuthFile(struct mg_connection *conn, const char *authFile) {
     FILE *fp = NULL;
-    int ret = 1;
 
-    if (!authFile) {
+    if (authFile == NULL) {
         mg_cry(conn, "warning: auth file not configured for this endpoint.\n");
-        ret = 0;
-        goto finalize;
+        return NULL;
     }
 
     fp = fopen(authFile, "r");
     if (fp == NULL) {
-        if (strerror_r(errno, errStr, sizeof(errStr)) == 0) {
-            mg_cry(conn, "error: auth file '%s' could not be accessed: %s\n", authFile, errStr);
-        } else {
-            mg_cry(conn, "error: auth file '%s' could not be accessed: %d\n", authFile, errno);
-        }
-        ret = 0;
+        LogError(errno, RS_RET_NO_FILE_ACCESS, "imhttp: auth file '%s' could not be accessed", authFile);
+    }
+    return fp;
+}
+
+/**
+ * Validate a Basic-auth request against an htpasswd file.
+ *
+ * @param conn CivetWeb request connection
+ * @param authFile htpasswd file path
+ * @return non-zero on successful authorization
+ *
+ * @note This preserves the pre-existing Basic-auth contract while sharing the
+ *       file-open path with API-key auth.
+ */
+static sbool authorize_basic(struct mg_connection *conn, const char *authFile) {
+    sbool ret = 0;
+    FILE *fp = NULL;
+    struct auth_s auth = {.pszUser = NULL, .pszPasswd = NULL, .pszApiKey = NULL};
+
+    fp = openAuthFile(conn, authFile);
+    if (fp == NULL) {
         goto finalize;
     }
 
-    ret = authorize(conn, fp);
+    if (!parse_basic_auth_header(conn, &auth)) {
+        goto finalize;
+    }
+
+    ret = read_auth_file(fp, &auth);
 
 finalize:
-    if (!ret) {
-        mg_send_http_error(conn, 401, "WWW-Authenticate: Basic realm=\"User Visible Realm\"\n");
-    }
-    if (fp) {
+    if (fp != NULL) {
         fclose(fp);
     }
     return ret;
+}
+
+/**
+ * Validate an API-key request against a token file.
+ *
+ * @param conn CivetWeb request connection
+ * @param authFile API-key file path
+ * @return non-zero on successful authorization
+ *
+ * @note One token per line keeps matching deterministic and avoids parser
+ *       ambiguity in the auth path.
+ */
+static sbool authorize_api_key(struct mg_connection *conn, const char *authFile) {
+    sbool ret = 0;
+    FILE *fp = NULL;
+    struct auth_s auth = {.pszUser = NULL, .pszPasswd = NULL, .pszApiKey = NULL};
+
+    fp = openAuthFile(conn, authFile);
+    if (fp == NULL) {
+        goto finalize;
+    }
+
+    if (!parse_api_key_header(conn, &auth)) {
+        goto finalize;
+    }
+
+    ret = read_api_key_file(fp, auth.pszApiKey);
+
+finalize:
+    if (fp != NULL) {
+        fclose(fp);
+    }
+    return ret;
+}
+
+/**
+ * Send the 401 response matching the route's configured auth scheme.
+ *
+ * @param conn CivetWeb request connection
+ * @param authCtx route-local auth state
+ *
+ * @note Basic auth advertises a challenge header so standard clients can retry.
+ *       API-key-only routes intentionally avoid a browser-oriented challenge.
+ */
+static void sendUnauthorized(struct mg_connection *conn, const struct route_auth_ctx_s *authCtx) {
+    if (authCtx != NULL && authCtx->pszBasicAuthFile != NULL) {
+        mg_send_http_error(conn, 401, "WWW-Authenticate: Basic realm=\"User Visible Realm\"\n");
+    } else {
+        mg_printf(conn, "HTTP/1.1 401 Unauthorized\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
+    }
+}
+
+/**
+ * CivetWeb auth callback for imhttp routes.
+ *
+ * @param conn CivetWeb request connection
+ * @param cbdata route-local auth context
+ * @return non-zero when the request is authorized
+ *
+ * @note When both schemes are configured, explicit Basic auth wins first so we
+ *       preserve the existing htpasswd behavior; API key auth is the fallback.
+ */
+static int routeAuthHandler(struct mg_connection *conn, void *cbdata) {
+    const struct route_auth_ctx_s *authCtx = (const struct route_auth_ctx_s *)cbdata;
+    const char *authHeader = mg_get_header(conn, "Authorization");
+    int ret = 0;
+
+    if (!routeAuthConfigured(authCtx)) {
+        return 1;
+    }
+
+    if (authCtx->pszBasicAuthFile != NULL && authHeader != NULL && strncasecmp(authHeader, "Basic ", 6) == 0) {
+        ret = authorize_basic(conn, authCtx->pszBasicAuthFile);
+    } else if (authCtx->pszApiKeyFile != NULL) {
+        ret = authorize_api_key(conn, authCtx->pszApiKeyFile);
+    }
+
+    if (!ret) {
+        sendUnauthorized(conn, authCtx);
+    }
+
+    return ret;
+}
+
+/**
+ * Register a request handler and attach auth handling when needed.
+ *
+ * @param ctx CivetWeb context
+ * @param path request path
+ * @param handler request handler
+ * @param handlerCbdata handler-specific callback data
+ * @param authCtx optional route-local auth context
+ *
+ * @note Keeping handler and auth registration together makes it easier to add
+ *       more mock endpoints later without duplicating the wiring rules.
+ */
+static void registerRoute(struct mg_context *ctx,
+                          const char *path,
+                          int (*handler)(struct mg_connection *, void *),
+                          void *handlerCbdata,
+                          struct route_auth_ctx_s *authCtx) {
+    if (ctx == NULL || path == NULL || path[0] == '\0') {
+        return;
+    }
+
+    mg_set_request_handler(ctx, path, handler, handlerCbdata);
+    if (routeAuthConfigured(authCtx)) {
+        mg_set_auth_handler(ctx, path, routeAuthHandler, authCtx);
+    }
 }
 
 /* cbdata should actually contain instance data and we can actually use this instance data
@@ -823,6 +1096,7 @@ finalize:
  */
 static int postHandler(struct mg_connection *conn, void *cbdata) {
     int rc = 1;
+    rsRetVal localRet = RS_RET_OK;
     instanceConf_t *inst = (instanceConf_t *)cbdata;
     const struct mg_request_info *ri = mg_get_request_info(conn);
     struct conn_wrkr_s *connWrkr = mg_get_thread_pointer(conn);
@@ -862,11 +1136,13 @@ static int postHandler(struct mg_connection *conn, void *cbdata) {
     if (ri->content_length >= 0) {
         /* We know the content length in advance */
         if (ri->content_length > (long long)connWrkr->readBufSize) {
-            connWrkr->pReadBuf = realloc(connWrkr->pReadBuf, ri->content_length + 1);
-            if (!connWrkr->pReadBuf) {
+            char *newReadBuf = realloc(connWrkr->pReadBuf, ri->content_length + 1);
+            if (newReadBuf == NULL) {
                 mg_cry(conn, "%s() - realloc failed!\n", __FUNCTION__);
+                rc = 500;
                 FINALIZE;
             }
+            connWrkr->pReadBuf = newReadBuf;
             connWrkr->readBufSize = ri->content_length + 1;
         }
     } else {
@@ -887,15 +1163,33 @@ static int postHandler(struct mg_connection *conn, void *cbdata) {
     while (1) {
         int count = mg_read(conn, connWrkr->pReadBuf, connWrkr->readBufSize);
         if (count > 0) {
-            processData(inst, connWrkr, (const char *)connWrkr->pReadBuf, count);
+            localRet = processData(inst, connWrkr, (const char *)connWrkr->pReadBuf, count);
+            if (localRet != RS_RET_OK) {
+                LogError(0, localRet, "imhttp: failed processing request payload");
+                STATSCOUNTER_INC(statsCounter.ctrFailed, statsCounter.mutCtrFailed);
+                rc = 500;
+                FINALIZE;
+            }
         } else {
             break;
         }
     }
 
     /* submit remainder */
-    doSubmitMsg(inst, connWrkr, connWrkr->pMsg, connWrkr->iMsg);
-    multiSubmitFlush(&connWrkr->multiSub);
+    localRet = doSubmitMsg(inst, connWrkr, connWrkr->pMsg, connWrkr->iMsg);
+    if (localRet != RS_RET_OK) {
+        LogError(0, localRet, "imhttp: failed submitting final request message");
+        STATSCOUNTER_INC(statsCounter.ctrFailed, statsCounter.mutCtrFailed);
+        rc = 500;
+        FINALIZE;
+    }
+    localRet = multiSubmitFlush(&connWrkr->multiSub);
+    if (localRet != RS_RET_OK) {
+        LogError(0, localRet, "imhttp: failed flushing submitted messages");
+        STATSCOUNTER_INC(statsCounter.ctrFailed, statsCounter.mutCtrFailed);
+        rc = 500;
+        FINALIZE;
+    }
 
     mg_send_http_ok(conn, "text/plain", 0);
     rc = 200;
@@ -1006,31 +1300,24 @@ static int runloop(void) {
         assert(inst->pszEndpoint);
         if (inst->pszEndpoint) {
             dbgprintf("setting request handler: '%s'\n", inst->pszEndpoint);
-            mg_set_request_handler(s_httpserv->ctx, (char *)inst->pszEndpoint, postHandler, inst);
-            if (inst->pszBasicAuthFile) {
-                mg_set_auth_handler(s_httpserv->ctx, (char *)inst->pszEndpoint, basicAuthHandler,
-                                    inst->pszBasicAuthFile);
-            }
+            routeAuthCtxSet(&inst->authCtx, (const char *)inst->pszBasicAuthFile, (const char *)inst->pszApiKeyFile);
+            registerRoute(s_httpserv->ctx, (const char *)inst->pszEndpoint, postHandler, inst, &inst->authCtx);
         }
     }
 
     if (runModConf->pszHealthCheckPath && runModConf->pszHealthCheckPath[0] != '\0') {
         dbgprintf("imhttp: setting request handler for global health check: '%s'\n", runModConf->pszHealthCheckPath);
-        mg_set_request_handler(s_httpserv->ctx, runModConf->pszHealthCheckPath, health_check_handler, NULL);
-        if (runModConf->pszHealthCheckAuthFile) {
-            mg_set_auth_handler(s_httpserv->ctx, runModConf->pszHealthCheckPath, basicAuthHandler,
-                                runModConf->pszHealthCheckAuthFile);
-        }
+        routeAuthCtxSet(&runModConf->healthCheckAuthCtx, runModConf->pszHealthCheckAuthFile,
+                        runModConf->pszHealthCheckApiKeyFile);
+        registerRoute(s_httpserv->ctx, runModConf->pszHealthCheckPath, health_check_handler, NULL,
+                      &runModConf->healthCheckAuthCtx);
     }
 
     if (runModConf->pszMetricsPath && runModConf->pszMetricsPath[0] != '\0') {
         dbgprintf("imhttp: setting request handler for Prometheus metrics: '%s'\n", runModConf->pszMetricsPath);
-        mg_set_request_handler(s_httpserv->ctx, runModConf->pszMetricsPath, prometheus_metrics_handler,
-                               NULL /* cbdata, not used */);
-        if (runModConf->pszMetricsAuthFile) {
-            mg_set_auth_handler(s_httpserv->ctx, runModConf->pszMetricsPath, basicAuthHandler,
-                                runModConf->pszMetricsAuthFile);
-        }
+        routeAuthCtxSet(&runModConf->metricsAuthCtx, runModConf->pszMetricsAuthFile, runModConf->pszMetricsApiKeyFile);
+        registerRoute(s_httpserv->ctx, runModConf->pszMetricsPath, prometheus_metrics_handler,
+                      NULL /* cbdata, not used */, &runModConf->metricsAuthCtx);
     }
 
     mg_unlock_context(s_httpserv->ctx);
@@ -1067,6 +1354,8 @@ BEGINnewInpInst
             inst->pszEndpoint = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
         } else if (!strcmp(inppblk.descr[i].name, "basicauthfile")) {
             inst->pszBasicAuthFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+        } else if (!strcmp(inppblk.descr[i].name, "apikeyfile")) {
+            inst->pszApiKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
         } else if (!strcmp(inppblk.descr[i].name, "ruleset")) {
             inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
         } else if (!strcmp(inppblk.descr[i].name, "name")) {
@@ -1134,6 +1423,8 @@ BEGINbeginCnfLoad
     loadModConf->options = NULL;
     loadModConf->pszHealthCheckAuthFile = NULL;
     loadModConf->pszMetricsAuthFile = NULL;
+    loadModConf->pszHealthCheckApiKeyFile = NULL;
+    loadModConf->pszMetricsApiKeyFile = NULL;
 ENDbeginCnfLoad
 
 
@@ -1185,6 +1476,12 @@ BEGINsetModCnf
         } else if (!strcmp(modpblk.descr[i].name, "metricsbasicauthfile")) {
             free(loadModConf->pszMetricsAuthFile);
             loadModConf->pszMetricsAuthFile = es_str2cstr(pvals[i].val.d.estr, NULL);
+        } else if (!strcmp(modpblk.descr[i].name, "healthcheckapikeyfile")) {
+            free(loadModConf->pszHealthCheckApiKeyFile);
+            loadModConf->pszHealthCheckApiKeyFile = es_str2cstr(pvals[i].val.d.estr, NULL);
+        } else if (!strcmp(modpblk.descr[i].name, "metricsapikeyfile")) {
+            free(loadModConf->pszMetricsApiKeyFile);
+            loadModConf->pszMetricsApiKeyFile = es_str2cstr(pvals[i].val.d.estr, NULL);
         } else {
             dbgprintf(
                 "imhttp: program error, non-handled "
@@ -1357,6 +1654,7 @@ BEGINfreeCnf
         }
         free(inst->pszEndpoint);
         free(inst->pszBasicAuthFile);
+        free(inst->pszApiKeyFile);
         free(inst->pszBindRuleset);
         free(inst->pszInputName);
         free(inst->pszRatelimitName);
@@ -1380,6 +1678,8 @@ BEGINfreeCnf
     free((void *)pModConf->pszMetricsPath);
     free((void *)pModConf->pszHealthCheckAuthFile);
     free((void *)pModConf->pszMetricsAuthFile);
+    free((void *)pModConf->pszHealthCheckApiKeyFile);
+    free((void *)pModConf->pszMetricsApiKeyFile);
 
     if (statsCounter.stats) {
         statsobj.Destruct(&statsCounter.stats);

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -528,6 +528,12 @@ EXTRA_DIST = \
     source/reference/parameters/imgssapi-inputgssserverpermitplaintcp.rst \
     source/reference/parameters/imgssapi-inputgssserverrun.rst \
     source/reference/parameters/imgssapi-inputgssserverservicename.rst \
+    source/reference/parameters/imhttp-apikeyfile.rst \
+    source/reference/parameters/imhttp-basicauthfile.rst \
+    source/reference/parameters/imhttp-healthcheckapikeyfile.rst \
+    source/reference/parameters/imhttp-healthcheckbasicauthfile.rst \
+    source/reference/parameters/imhttp-metricsapikeyfile.rst \
+    source/reference/parameters/imhttp-metricsbasicauthfile.rst \
     source/reference/parameters/imhttp-ratelimit-name.rst \
     source/reference/parameters/imjournal-defaultfacility.rst \
     source/reference/parameters/imjournal-defaultseverity.rst \

--- a/doc/source/configuration/modules/imhttp.rst
+++ b/doc/source/configuration/modules/imhttp.rst
@@ -106,24 +106,36 @@ healthCheckPath
 Configures the request path for a simple HTTP health probe that returns
 ``200`` when the module is running.
 The endpoint is unauthenticated unless :ref:`healthCheckBasicAuthFile
-<imhttp-healthcheckbasicauthfile>` is set. Otherwise, bind the server to
+<imhttp-healthcheckbasicauthfile>` or :ref:`healthCheckApiKeyFile
+<imhttp-healthcheckapikeyfile>` is set. Otherwise, bind the server to
 ``localhost`` or use CivetWeb access controls if external access is not
 desired.
 
-.. _imhttp-healthcheckbasicauthfile:
+Authentication Parameters
+-------------------------
 
-healthCheckBasicAuthFile
-^^^^^^^^^^^^^^^^^^^^^^^^
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
 
-.. csv-table::
-   :header: "type", "mandatory", "format", "default"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "no", "path to htpasswd file", "none"
-
-Protects the health probe with HTTP Basic Authentication using a file in
-`htpasswd` format.
+   * - Parameter
+     - Summary
+   * - :ref:`param-imhttp-healthcheckbasicauthfile`
+     - .. include:: ../../reference/parameters/imhttp-healthcheckbasicauthfile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imhttp-healthcheckapikeyfile`
+     - .. include:: ../../reference/parameters/imhttp-healthcheckapikeyfile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imhttp-metricsbasicauthfile`
+     - .. include:: ../../reference/parameters/imhttp-metricsbasicauthfile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imhttp-metricsapikeyfile`
+     - .. include:: ../../reference/parameters/imhttp-metricsapikeyfile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 .. _imhttp-metricspath:
 
@@ -141,24 +153,28 @@ Exposes rsyslog statistics in Prometheus text format at the specified
 path. The endpoint emits counters such as ``imhttp_submitted_total`` and
 ``imhttp_failed_total``.
 By default the endpoint does not enforce authentication, but it can be
-protected with :ref:`metricsBasicAuthFile <imhttp-metricsbasicauthfile>`.
+protected with :ref:`metricsBasicAuthFile <imhttp-metricsbasicauthfile>`
+or :ref:`metricsApiKeyFile <imhttp-metricsapikeyfile>`.
 Leaving the default paths enabled creates user-visible URLs as soon as
 the module is loaded, so review firewall and access-control settings.
 
-.. _imhttp-metricsbasicauthfile:
+Authentication Parameters
+-------------------------
 
-metricsBasicAuthFile
-^^^^^^^^^^^^^^^^^^^^
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
 
-.. csv-table::
-   :header: "type", "mandatory", "format", "default"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "no", "path to htpasswd file", "none"
-
-Protects the metrics endpoint with HTTP Basic Authentication using a
-file in `htpasswd` format.
+   * - Parameter
+     - Summary
+   * - :ref:`param-imhttp-metricsbasicauthfile`
+     - .. include:: ../../reference/parameters/imhttp-metricsbasicauthfile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imhttp-metricsapikeyfile`
+     - .. include:: ../../reference/parameters/imhttp-metricsapikeyfile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 Input Parameters
 ----------------
@@ -307,41 +323,26 @@ The following metadata will be injected into the following properties:
   for case-insensitive access.
 
 
-basicAuthFile
-^^^^^^^^^^^^^^^^^^
+Authentication Parameters
+-------------------------
 
-.. csv-table::
-   :header: "type", "mandatory", "format", "default"
-   :widths: auto
-   :class: parameter-table
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
 
-   "string", "no", "none", ""
-
-Enables access control to this endpoint using HTTP basic authentication. Option is disabled by default.
-To enable it, set this option to an `htpasswd file`, which can be generated using a standard `htpasswd` tool.
-
-See also:
-
-- `HTTP Authorization <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization>`_
-- `HTTP Basic Authentication <https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme>`_
-- `htpasswd utility <https://httpd.apache.org/docs/2.4/programs/htpasswd.html>`_
+   * - Parameter
+     - Summary
+   * - :ref:`param-imhttp-basicauthfile`
+     - .. include:: ../../reference/parameters/imhttp-basicauthfile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imhttp-apikeyfile`
+     - .. include:: ../../reference/parameters/imhttp-apikeyfile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 
 .. _imhttp-statistic-counter:
-
-
-basicAuthFile
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "mandatory", "format", "default"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "no", "none", "none"
-
-Configures an `htpasswd <https://httpd.apache.org/docs/2.4/programs/htpasswd.html>`_ file and enables `basic authentication <https://en.wikipedia.org/wiki/Basic_access_authentication>`_ on HTTP request received on this input.
-If this option is not set, basic authentication will not be enabled.
 
 
 Statistic Counter
@@ -513,3 +514,47 @@ Authentication:
 
    # scrape statistics with credentials
    # curl -u user:password http://localhost:8080/metrics
+
+Example 7
+---------
+
+Protect an input endpoint with API-key authentication:
+
+.. code-block:: none
+
+   module(load="imhttp" ports="8080")
+   input(type="imhttp"
+         endpoint="/postrequest"
+         apiKeyFile="/etc/rsyslog/imhttp-apikeys")
+
+   # send logs with an API key
+   # curl -H 'Authorization: ApiKey secret-token' \
+   #      -d 'message payload' http://localhost:8080/postrequest
+
+Example 8
+---------
+
+Allow either Basic or API-key authentication on the same input during a
+migration:
+
+.. code-block:: none
+
+   module(load="imhttp" ports="8080")
+   input(type="imhttp"
+         endpoint="/postrequest"
+         basicAuthFile="/etc/rsyslog/htpasswd"
+         apiKeyFile="/etc/rsyslog/imhttp-apikeys")
+
+Example 9
+---------
+
+Protect the metrics endpoint with an API key:
+
+.. code-block:: none
+
+   module(load="imhttp" ports="8080"
+          metricsPath="/metrics"
+          metricsApiKeyFile="/etc/rsyslog/imhttp-apikeys")
+
+   # scrape statistics with an API key
+   # curl -H 'Authorization: ApiKey secret-token' http://localhost:8080/metrics

--- a/doc/source/reference/parameters/imhttp-apikeyfile.rst
+++ b/doc/source/reference/parameters/imhttp-apikeyfile.rst
@@ -1,0 +1,56 @@
+.. meta::
+   :description: Configure imhttp to protect an input with API key authentication.
+   :keywords: rsyslog, imhttp, apikeyfile, api key authentication, http
+
+.. _param-imhttp-apikeyfile:
+.. _imhttp.parameter.input.apikeyfile:
+.. _imhttp-apikeyfile:
+
+apiKeyFile
+==========
+
+.. index::
+   single: imhttp; apiKeyFile
+   single: apiKeyFile
+
+.. summary-start
+
+Protects an imhttp input with API key authentication using tokens listed in a file.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imhttp`.
+
+:Name: apiKeyFile
+:Scope: input
+:Type: string
+:Default: none
+:Required?: no
+:Introduced: Not specified
+
+Description
+-----------
+If set, imhttp reads one API key token per line from the specified file and
+accepts matching HTTP ``Authorization: ApiKey`` or ``X-API-Key`` credentials.
+Leading whitespace after ``ApiKey`` and ``X-API-Key`` is ignored.
+
+Blank lines and lines starting with ``#`` are ignored.
+
+If both ``basicAuthFile`` and ``apiKeyFile`` are configured for the same input,
+either authentication method is accepted.
+
+Input usage
+-----------
+.. _imhttp.parameter.input.apikeyfile-usage:
+
+.. code-block:: rsyslog
+
+   input(
+       type="imhttp"
+       endpoint="/ingest"
+       apiKeyFile="/etc/rsyslog/api-keys.txt"
+   )
+
+See also
+--------
+See also :doc:`../../configuration/modules/imhttp`.

--- a/doc/source/reference/parameters/imhttp-basicauthfile.rst
+++ b/doc/source/reference/parameters/imhttp-basicauthfile.rst
@@ -1,0 +1,55 @@
+.. meta::
+   :description: Configure imhttp to protect an input with HTTP Basic Authentication.
+   :keywords: rsyslog, imhttp, basicauthfile, http basic authentication
+
+.. _param-imhttp-basicauthfile:
+.. _imhttp.parameter.input.basicauthfile:
+.. _imhttp-basicauthfile:
+
+basicAuthFile
+=============
+
+.. index::
+   single: imhttp; basicAuthFile
+   single: basicAuthFile
+
+.. summary-start
+
+Protects an imhttp input with HTTP Basic Authentication using an htpasswd file.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imhttp`.
+
+:Name: basicAuthFile
+:Scope: input
+:Type: string
+:Default: none
+:Required?: no
+:Introduced: Not specified
+
+Description
+-----------
+imhttp accepts ``Authorization: Basic`` credentials for the input when this
+parameter is set. The htpasswd file is read line-by-line and blank lines or
+``#`` comments are ignored.
+
+For safety, the Basic-auth header is capped at 2048 Base64 characters. That is
+already larger than practical Basic-auth credentials, but small enough to keep
+the parser on a fixed stack buffer and reject oversized headers outright.
+
+Input usage
+-----------
+.. _imhttp.parameter.input.basicauthfile-usage:
+
+.. code-block:: rsyslog
+
+   input(
+       type="imhttp"
+       endpoint="/ingest"
+       basicAuthFile="/etc/rsyslog/htpasswd"
+   )
+
+See also
+--------
+See also :doc:`../../configuration/modules/imhttp`.

--- a/doc/source/reference/parameters/imhttp-healthcheckapikeyfile.rst
+++ b/doc/source/reference/parameters/imhttp-healthcheckapikeyfile.rst
@@ -1,0 +1,52 @@
+.. meta::
+   :description: Protect the imhttp health check endpoint with API key authentication.
+   :keywords: rsyslog, imhttp, healthcheck, api key authentication
+
+.. _param-imhttp-healthcheckapikeyfile:
+.. _imhttp.parameter.module.healthcheckapikeyfile:
+.. _imhttp-healthcheckapikeyfile:
+
+healthCheckApiKeyFile
+=====================
+
+.. index::
+   single: imhttp; healthCheckApiKeyFile
+   single: healthCheckApiKeyFile
+
+.. summary-start
+
+Protects the imhttp health check endpoint with API key authentication.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imhttp`.
+
+:Name: healthCheckApiKeyFile
+:Scope: module
+:Type: string
+:Default: none
+:Required?: no
+:Introduced: Not specified
+
+Description
+-----------
+If set, the health check endpoint accepts matching API key tokens from a file.
+Accepted request headers are ``Authorization: ApiKey`` and ``X-API-Key``.
+Leading whitespace after the header scheme is ignored.
+
+Blank lines and lines starting with ``#`` are ignored.
+
+Module usage
+------------
+.. _imhttp.parameter.module.healthcheckapikeyfile-usage:
+
+.. code-block:: rsyslog
+
+   module(
+       load="imhttp"
+       healthCheckApiKeyFile="/etc/rsyslog/api-keys.txt"
+   )
+
+See also
+--------
+See also :doc:`../../configuration/modules/imhttp`.

--- a/doc/source/reference/parameters/imhttp-healthcheckbasicauthfile.rst
+++ b/doc/source/reference/parameters/imhttp-healthcheckbasicauthfile.rst
@@ -1,0 +1,49 @@
+.. meta::
+   :description: Protect the imhttp health check endpoint with HTTP Basic Authentication.
+   :keywords: rsyslog, imhttp, healthcheck, basicauthfile, http basic authentication
+
+.. _param-imhttp-healthcheckbasicauthfile:
+.. _imhttp.parameter.module.healthcheckbasicauthfile:
+.. _imhttp-healthcheckbasicauthfile:
+
+healthCheckBasicAuthFile
+========================
+
+.. index::
+   single: imhttp; healthCheckBasicAuthFile
+   single: healthCheckBasicAuthFile
+
+.. summary-start
+
+Protects the imhttp health check endpoint with HTTP Basic Authentication.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imhttp`.
+
+:Name: healthCheckBasicAuthFile
+:Scope: module
+:Type: string
+:Default: none
+:Required?: no
+:Introduced: Not specified
+
+Description
+-----------
+If set, the health check endpoint requires HTTP Basic Authentication and
+expects credentials from an htpasswd file.
+
+Module usage
+------------
+.. _imhttp.parameter.module.healthcheckbasicauthfile-usage:
+
+.. code-block:: rsyslog
+
+   module(
+       load="imhttp"
+       healthCheckBasicAuthFile="/etc/rsyslog/htpasswd"
+   )
+
+See also
+--------
+See also :doc:`../../configuration/modules/imhttp`.

--- a/doc/source/reference/parameters/imhttp-metricsapikeyfile.rst
+++ b/doc/source/reference/parameters/imhttp-metricsapikeyfile.rst
@@ -1,0 +1,52 @@
+.. meta::
+   :description: Protect the imhttp metrics endpoint with API key authentication.
+   :keywords: rsyslog, imhttp, metrics, api key authentication
+
+.. _param-imhttp-metricsapikeyfile:
+.. _imhttp.parameter.module.metricsapikeyfile:
+.. _imhttp-metricsapikeyfile:
+
+metricsApiKeyFile
+=================
+
+.. index::
+   single: imhttp; metricsApiKeyFile
+   single: metricsApiKeyFile
+
+.. summary-start
+
+Protects the imhttp Prometheus metrics endpoint with API key authentication.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imhttp`.
+
+:Name: metricsApiKeyFile
+:Scope: module
+:Type: string
+:Default: none
+:Required?: no
+:Introduced: Not specified
+
+Description
+-----------
+If set, the metrics endpoint accepts matching API key tokens from a file.
+Accepted request headers are ``Authorization: ApiKey`` and ``X-API-Key``.
+Leading whitespace after the header scheme is ignored.
+
+Blank lines and lines starting with ``#`` are ignored.
+
+Module usage
+------------
+.. _imhttp.parameter.module.metricsapikeyfile-usage:
+
+.. code-block:: rsyslog
+
+   module(
+       load="imhttp"
+       metricsApiKeyFile="/etc/rsyslog/api-keys.txt"
+   )
+
+See also
+--------
+See also :doc:`../../configuration/modules/imhttp`.

--- a/doc/source/reference/parameters/imhttp-metricsbasicauthfile.rst
+++ b/doc/source/reference/parameters/imhttp-metricsbasicauthfile.rst
@@ -1,0 +1,49 @@
+.. meta::
+   :description: Protect the imhttp metrics endpoint with HTTP Basic Authentication.
+   :keywords: rsyslog, imhttp, metrics, basicauthfile, http basic authentication
+
+.. _param-imhttp-metricsbasicauthfile:
+.. _imhttp.parameter.module.metricsbasicauthfile:
+.. _imhttp-metricsbasicauthfile:
+
+metricsBasicAuthFile
+====================
+
+.. index::
+   single: imhttp; metricsBasicAuthFile
+   single: metricsBasicAuthFile
+
+.. summary-start
+
+Protects the imhttp Prometheus metrics endpoint with HTTP Basic Authentication.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imhttp`.
+
+:Name: metricsBasicAuthFile
+:Scope: module
+:Type: string
+:Default: none
+:Required?: no
+:Introduced: Not specified
+
+Description
+-----------
+If set, the metrics endpoint requires HTTP Basic Authentication and expects
+credentials from an htpasswd file.
+
+Module usage
+------------
+.. _imhttp.parameter.module.metricsbasicauthfile-usage:
+
+.. code-block:: rsyslog
+
+   module(
+       load="imhttp"
+       metricsBasicAuthFile="/etc/rsyslog/htpasswd"
+   )
+
+See also
+--------
+See also :doc:`../../configuration/modules/imhttp`.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -977,6 +977,9 @@ TESTS_IMDOCKER_VALGRIND = \
 TESTS_IMHTTP = \
 	imhttp-post-payload.sh \
 	imhttp-post-payload-basic-auth.sh \
+	imhttp-post-payload-api-key-auth.sh \
+	imhttp-post-payload-auth-header-limits.sh \
+	imhttp-post-payload-mixed-auth.sh \
 	imhttp-post-payload-query-params.sh \
 	imhttp-post-payload-large.sh \
 	imhttp-post-payload-multi.sh \
@@ -985,6 +988,8 @@ TESTS_IMHTTP = \
 	imhttp-getrequest-file.sh \
 	imhttp-healthcheck.sh \
 	imhttp-metrics.sh \
+	imhttp-healthcheck-api-key-auth.sh \
+	imhttp-metrics-api-key-auth.sh \
 	imhttp_ratelimit_name.sh
 
 TESTS_IMHTTP_VALGRIND = \
@@ -1231,6 +1236,10 @@ TESTS_OMSTDOUT = \
 TESTS_LIBYAML_IMTCP = \
 	config-translate-rs-roundtrip.sh \
 	config-translate-yaml-roundtrip.sh
+
+TESTS_LIBYAML_IMHTTP = \
+	yaml-imhttp-apikeyfile.sh \
+	yaml-imhttp-metrics-apikeyfile.sh
 
 TESTS_LIBYAML_OMSTDOUT = \
 	config-translate-legacy-warning.sh
@@ -1754,6 +1763,7 @@ EXTRA_DIST += $(TESTS_LIBGCRYPT_VALGRIND)
 EXTRA_DIST += $(TESTS_LIBYAML)
 EXTRA_DIST += $(TESTS_RATELIMIT_WATCH)
 EXTRA_DIST += $(TESTS_LIBYAML_IMTCP)
+EXTRA_DIST += $(TESTS_LIBYAML_IMHTTP)
 EXTRA_DIST += $(TESTS_LIBYAML_OMSTDOUT)
 EXTRA_DIST += $(TESTS_IMTCP)
 EXTRA_DIST += $(TESTS_IMTCP_YAML)
@@ -2132,6 +2142,9 @@ endif # ENABLE_INOTIFY
 if ENABLE_IMTCP_TESTS
 TESTS += $(TESTS_LIBYAML_IMTCP)
 endif # ENABLE_IMTCP_TESTS
+if ENABLE_IMHTTP
+TESTS += $(TESTS_LIBYAML_IMHTTP)
+endif # ENABLE_IMHTTP
 if ENABLE_OMSTDOUT
 TESTS += $(TESTS_LIBYAML_OMSTDOUT)
 endif # ENABLE_OMSTDOUT
@@ -3089,6 +3102,7 @@ EXTRA_DIST += \
 	testsuites/action-tx-errfile.result \
 	improg-multiline-test.py \
 	testsuites/imhttp-large-data.txt \
+	testsuites/imhttp-apikeys.txt \
 	testsuites/docroot/file.txt \
 	testsuites/htpasswd \
 	omhttp_server.py \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -243,6 +243,49 @@ require_plugin() {
         exit 77
 }
 
+# ensure YAML config support is available before running yaml-only tests.
+# Skips only when the binary was built without libyaml; any other validation
+# failure indicates a broken probe and is treated as a testbench error.
+require_yaml_support() {
+	local yaml_probe="${RSYSLOG_DYNNAME}.yaml-support-check.yaml"
+	local yaml_probe_log="${RSYSLOG_DYNNAME}.yaml-support-check.log"
+
+	cat > "$yaml_probe" << 'EOF'
+version: 2
+
+templates:
+  - name: outfmt
+    type: string
+    string: "%msg%\n"
+
+rulesets:
+  - name: main
+    script: |
+      action(type="omfile" file="/dev/null" template="outfmt")
+EOF
+
+	../tools/rsyslogd -C -N1 -f "$yaml_probe" -M"$RSYSLOG_MODDIR" \
+		> "$yaml_probe_log" 2>&1
+	local rc=$?
+	rm -f "$yaml_probe"
+
+	if [ $rc -eq 0 ]; then
+		rm -f "$yaml_probe_log"
+		return 0
+	fi
+
+	if grep -q "requested but rsyslog was built without libyaml support" "$yaml_probe_log"; then
+		printf 'info: skipping test - rsyslog was built without libyaml support\n'
+		rm -f "$yaml_probe_log"
+		exit 77
+	fi
+
+	printf 'TESTBENCH_ERROR: YAML support probe failed unexpectedly\n'
+	cat "$yaml_probe_log"
+	rm -f "$yaml_probe_log"
+	error_exit 100
+}
+
 
 
 # a consistent format to output testbench timestamps

--- a/tests/imhttp-healthcheck-api-key-auth.sh
+++ b/tests/imhttp-healthcheck-api-key-auth.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+IMHTTP_PORT="$(get_free_port)"
+add_conf '
+module(load="../contrib/imhttp/.libs/imhttp"
+       ports="'$IMHTTP_PORT'"
+       healthCheckApiKeyFile="'$srcdir'/testsuites/imhttp-apikeys.txt")
+'
+startup
+
+ret=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:$IMHTTP_PORT/healthz)
+if [ "$ret" != "401" ]; then
+  echo "ERROR: expected 401 without API key, got $ret"
+  error_exit 1
+fi
+
+curl -s -H 'Authorization: ApiKey secret-token-1' \
+  http://localhost:$IMHTTP_PORT/healthz > "$RSYSLOG_OUT_LOG"
+
+shutdown_when_empty
+wait_shutdown
+content_check "OK"
+exit_test

--- a/tests/imhttp-metrics-api-key-auth.sh
+++ b/tests/imhttp-metrics-api-key-auth.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+IMHTTP_PORT="$(get_free_port)"
+add_conf '
+module(load="../contrib/imhttp/.libs/imhttp"
+       ports="'$IMHTTP_PORT'"
+       metricsPath="/metrics"
+       metricsApiKeyFile="'$srcdir'/testsuites/imhttp-apikeys.txt")
+'
+startup
+
+ret=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:$IMHTTP_PORT/metrics)
+if [ "$ret" != "401" ]; then
+  echo "ERROR: expected 401 without API key, got $ret"
+  error_exit 1
+fi
+
+curl -s -H 'Authorization: ApiKey secret-token-2' \
+  http://localhost:$IMHTTP_PORT/metrics > "$RSYSLOG_OUT_LOG"
+
+shutdown_when_empty
+wait_shutdown
+content_check "imhttp_up 1"
+exit_test

--- a/tests/imhttp-post-payload-api-key-auth.sh
+++ b/tests/imhttp-post-payload-api-key-auth.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+IMHTTP_PORT="$(get_free_port)"
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+module(load="../contrib/imhttp/.libs/imhttp"
+       ports="'$IMHTTP_PORT'")
+input(type="imhttp" endpoint="/postrequest"
+      ruleset="ruleset"
+      apiKeyFile="'$srcdir'/testsuites/imhttp-apikeys.txt")
+ruleset(name="ruleset") {
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+'
+startup
+
+ret=$(curl -s -o /dev/null -w '%{http_code}' \
+  -H 'Authorization: ApiKey wrong-token' \
+  -H Content-Type:application/json \
+  http://localhost:$IMHTTP_PORT/postrequest \
+  -d '[{"foo":"bar"}]')
+if [ "$ret" != "401" ]; then
+  echo "ERROR: expected 401 for invalid API key, got $ret"
+  error_exit 1
+fi
+
+ret=$(curl -s -o /dev/null -w '%{http_code}' \
+  -H 'Authorization: ApiKey secret-token-1' \
+  -H Content-Type:application/json \
+  http://localhost:$IMHTTP_PORT/postrequest \
+  -d '[{"foo":"bar"}]')
+if [ "$ret" != "200" ]; then
+  echo "ERROR: expected 200 for valid API key, got $ret"
+  error_exit 1
+fi
+
+wait_queueempty
+shutdown_when_empty
+wait_shutdown
+content_check '[{"foo":"bar"}]'
+exit_test

--- a/tests/imhttp-post-payload-auth-header-limits.sh
+++ b/tests/imhttp-post-payload-auth-header-limits.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+IMHTTP_PORT="$(get_free_port)"
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+module(load="../contrib/imhttp/.libs/imhttp"
+       ports="'$IMHTTP_PORT'")
+input(type="imhttp" endpoint="/postrequest"
+      ruleset="ruleset"
+      basicAuthFile="'$srcdir'/testsuites/htpasswd"
+      apiKeyFile="'$srcdir'/testsuites/imhttp-apikeys.txt")
+ruleset(name="ruleset") {
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+'
+startup
+
+LONG_AUTH_VALUE="$(python3 - <<'PY'
+print("A" * 20000)
+PY
+)"
+
+assert_rejected() {
+  local header_name="$1"
+  local header_value="$2"
+  local ret
+
+  ret=$(curl -s -o /dev/null -w '%{http_code}' \
+    -H "$header_name: $header_value" \
+    -H Content-Type:application/json \
+    http://localhost:$IMHTTP_PORT/postrequest \
+    -d '[{"msg":"rejected"}]')
+
+  if [ "$ret" = "200" ]; then
+    echo "ERROR: oversized $header_name unexpectedly succeeded"
+    error_exit 1
+  fi
+}
+
+assert_rejected "Authorization" "ApiKey $LONG_AUTH_VALUE"
+assert_rejected "Authorization" "Basic $LONG_AUTH_VALUE"
+assert_rejected "X-API-Key" "$LONG_AUTH_VALUE"
+
+ret=$(curl -s -o /dev/null -w '%{http_code}' \
+  -H 'X-API-Key:    secret-token-1' \
+  -H Content-Type:application/json \
+  http://localhost:$IMHTTP_PORT/postrequest \
+  -d '[{"msg":"whitespace-key"}]')
+if [ "$ret" != "200" ]; then
+  echo "ERROR: expected 200 for whitespace-padded X-API-Key, got $ret"
+  error_exit 1
+fi
+
+ret=$(curl -s -o /dev/null -w '%{http_code}' \
+  --user user1:1234 \
+  -H Content-Type:application/json \
+  http://localhost:$IMHTTP_PORT/postrequest \
+  -d '[{"msg":"basic-ok"}]')
+if [ "$ret" != "200" ]; then
+  echo "ERROR: expected 200 for valid basic auth after oversized headers, got $ret"
+  error_exit 1
+fi
+
+wait_queueempty
+shutdown_when_empty
+wait_shutdown
+content_count_check '[{"msg":"rejected"}]' 0
+content_count_check '[{"msg":"whitespace-key"}]' 1
+content_count_check '[{"msg":"basic-ok"}]' 1
+exit_test

--- a/tests/imhttp-post-payload-mixed-auth.sh
+++ b/tests/imhttp-post-payload-mixed-auth.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+IMHTTP_PORT="$(get_free_port)"
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+module(load="../contrib/imhttp/.libs/imhttp"
+       ports="'$IMHTTP_PORT'")
+input(type="imhttp" endpoint="/postrequest"
+      ruleset="ruleset"
+      basicAuthFile="'$srcdir'/testsuites/htpasswd"
+      apiKeyFile="'$srcdir'/testsuites/imhttp-apikeys.txt")
+ruleset(name="ruleset") {
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+'
+startup
+
+ret=$(curl -s -o /dev/null -w '%{http_code}' \
+  -H Content-Type:application/json \
+  http://localhost:$IMHTTP_PORT/postrequest \
+  -d '[{"msg":"unauthorized"}]')
+if [ "$ret" != "401" ]; then
+  echo "ERROR: expected 401 without auth, got $ret"
+  error_exit 1
+fi
+
+ret=$(curl -s -o /dev/null -w '%{http_code}' \
+  --user user1:1234 \
+  -H Content-Type:application/json \
+  http://localhost:$IMHTTP_PORT/postrequest \
+  -d '[{"msg":"basic"}]')
+if [ "$ret" != "200" ]; then
+  echo "ERROR: expected 200 for valid basic auth, got $ret"
+  error_exit 1
+fi
+
+ret=$(curl -s -o /dev/null -w '%{http_code}' \
+  -H 'Authorization: ApiKey secret-token-2' \
+  -H Content-Type:application/json \
+  http://localhost:$IMHTTP_PORT/postrequest \
+  -d '[{"msg":"apikey"}]')
+if [ "$ret" != "200" ]; then
+  echo "ERROR: expected 200 for valid API key, got $ret"
+  error_exit 1
+fi
+
+wait_queueempty
+shutdown_when_empty
+wait_shutdown
+content_count_check '[{"msg":"basic"}]' 1
+content_count_check '[{"msg":"apikey"}]' 1
+exit_test

--- a/tests/testsuites/imhttp-apikeys.txt
+++ b/tests/testsuites/imhttp-apikeys.txt
@@ -1,0 +1,4 @@
+# Valid API keys for imhttp test coverage
+
+secret-token-1
+secret-token-2

--- a/tests/yaml-imhttp-apikeyfile.sh
+++ b/tests/yaml-imhttp-apikeyfile.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+require_yaml_support
+IMHTTP_PORT="$(get_free_port)"
+generate_conf --yaml-only
+add_yaml_conf 'modules:'
+add_yaml_conf '  - load: "../contrib/imhttp/.libs/imhttp"'
+add_yaml_conf '    ports: "'$IMHTTP_PORT'"'
+add_yaml_conf 'templates:'
+add_yaml_conf '  - name: outfmt'
+add_yaml_conf '    type: string'
+add_yaml_conf '    string: "%msg%\n"'
+add_yaml_conf 'inputs:'
+add_yaml_imdiag_input
+add_yaml_conf '  - type: imhttp'
+add_yaml_conf '    endpoint: "/postrequest"'
+add_yaml_conf '    ruleset: "main"'
+add_yaml_conf '    apiKeyFile: "'$srcdir'/testsuites/imhttp-apikeys.txt"'
+add_yaml_conf 'rulesets:'
+add_yaml_conf '  - name: main'
+add_yaml_conf '    script: |'
+add_yaml_conf '      action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")'
+startup
+
+ret=$(curl -s -o /dev/null -w '%{http_code}' \
+  -H 'Authorization: ApiKey secret-token-1' \
+  -H Content-Type:application/json \
+  http://localhost:$IMHTTP_PORT/postrequest \
+  -d '[{"yaml":"apikey"}]')
+if [ "$ret" != "200" ]; then
+  echo "ERROR: expected 200 for valid API key in YAML config, got $ret"
+  error_exit 1
+fi
+
+wait_queueempty
+shutdown_when_empty
+wait_shutdown
+content_check '[{"yaml":"apikey"}]'
+exit_test

--- a/tests/yaml-imhttp-metrics-apikeyfile.sh
+++ b/tests/yaml-imhttp-metrics-apikeyfile.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+require_yaml_support
+IMHTTP_PORT="$(get_free_port)"
+generate_conf --yaml-only
+add_yaml_conf 'modules:'
+add_yaml_conf '  - load: "../contrib/imhttp/.libs/imhttp"'
+add_yaml_conf '    ports: "'$IMHTTP_PORT'"'
+add_yaml_conf '    metricsPath: "/metrics"'
+add_yaml_conf '    metricsApiKeyFile: "'$srcdir'/testsuites/imhttp-apikeys.txt"'
+add_yaml_conf 'inputs:'
+add_yaml_imdiag_input
+add_yaml_conf '  - type: imhttp'
+add_yaml_conf '    endpoint: "/unused"'
+add_yaml_conf '    ruleset: "main"'
+add_yaml_conf 'rulesets:'
+add_yaml_conf '  - name: main'
+add_yaml_conf '    script: |'
+add_yaml_conf '      action(type="omfile" file="'$RSYSLOG_OUT_LOG'.unused")'
+startup
+
+ret=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:$IMHTTP_PORT/metrics)
+if [ "$ret" != "401" ]; then
+  echo "ERROR: expected 401 without API key in YAML metrics config, got $ret"
+  error_exit 1
+fi
+
+curl -s -H 'Authorization: ApiKey secret-token-1' \
+  http://localhost:$IMHTTP_PORT/metrics > "$RSYSLOG_OUT_LOG"
+
+shutdown_when_empty
+wait_shutdown
+content_check "imhttp_up 1"
+exit_test


### PR DESCRIPTION
## Summary
- add route-scoped auth handling to `imhttp` so each endpoint can run with no auth, Basic auth, API-key auth, or mixed Basic + API key auth
- add `apiKeyFile` support for inputs plus `healthCheckApiKeyFile` and `metricsApiKeyFile` for the built-in endpoints
- fix nearby `imhttp` issues uncovered during the work, including safer auth parsing/cleanup and better request error handling
- document the new parameters and examples
- add shell and YAML regression tests for API-key and mixed-auth behavior

## Validation
- `make -j$(nproc) check TESTS=""`
- `tests/imhttp-post-payload-basic-auth.sh`
- `tests/imhttp-post-payload-api-key-auth.sh`
- `tests/imhttp-post-payload-mixed-auth.sh`
- `tests/imhttp-healthcheck-api-key-auth.sh`
- `tests/imhttp-metrics-api-key-auth.sh`
- `tests/yaml-imhttp-apikeyfile.sh`
- `tests/yaml-imhttp-metrics-apikeyfile.sh`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)`